### PR TITLE
Use custom hostname when applying remote config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.direnv
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-.direnv
-.envrc

--- a/flake.nix
+++ b/flake.nix
@@ -122,7 +122,7 @@
                           options = {
                             name = mkOption {
                               type = str;
-                              default = "testing-${cfg.networking.hostName}";
+                              default = "testing-${cfg.services.comin.hostname}";
                               description = "The name of the testing branch.";
                             };
                           };

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,7 @@
       cfg = config;
       yaml = pkgs.formats.yaml { };
       cominConfig = {
-        hostname = config.networking.hostName;
+        hostname = cfg.services.comin.hostname;
         state_dir = "/var/lib/comin";
         remotes = cfg.services.comin.remotes;
       } // (
@@ -59,6 +59,13 @@
             default = false;
             description = ''
               Whether to run the comin service.
+            '';
+          };
+          hostname = mkOption {
+            type = str;
+            default = config.networking.hostName;
+            description = ''
+              The hostname of the machine.
             '';
           };
           remotes = mkOption {
@@ -194,7 +201,6 @@
         };
       };
     };
-
     devShell.x86_64-linux = let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in pkgs.mkShell {


### PR DESCRIPTION
Hey there! I am using comin to manage my nixos dev environment and I ran into the following scenario 

My nixos flake is defined with the hostname "hello" and my networking hostname is "dev". When I try to apply the configuration with comin, comin uses the networking hostname which does not exist on my config, thus failing. This changes adds a config option to configure hostname in the service, so that it applies the correct hostname when updating. 

This could also work as a per remote config but I didn't see an obvious way to do that from my limited view. 

Figured I'd contribute this back since it immediately unblocks my use case. 