### PR TITLE
support for subdirectories

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -55,7 +55,7 @@ var runCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		manager := manager.New(repository, store, metrics, gitConfig.Path, cfg.Hostname, machineId)
+		manager := manager.New(repository, store, metrics, gitConfig.Path, gitConfig.Dir, cfg.Hostname, machineId)
 		go poller.Poller(manager, cfg.Remotes)
 		http.Serve(manager,
 			metrics,

--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -104,6 +104,24 @@ signed integer
 
 
 
+## services\.comin\.flake_subdirectory
+
+
+
+Subdirectory in the repository, containing flake\.nix\.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "." `
+
+
+
 ## services\.comin\.hostname
 
 
@@ -367,23 +385,5 @@ The URL of the repository\.
 
 *Type:*
 string
-
-
-
-## services\.comin\.repo_dir
-
-
-
-Subdirectory in the repository, containing flake\.nix\.
-
-
-
-*Type:*
-string
-
-
-
-*Default:*
-` "." `
 
 

--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -369,3 +369,21 @@ The URL of the repository\.
 string
 
 
+
+## services\.comin\.repo_dir
+
+
+
+Subdirectory in the repository, containing flake\.nix\.
+
+
+
+*Type:*
+string
+
+
+
+*Default:*
+` "." `
+
+

--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -104,7 +104,7 @@ signed integer
 
 
 
-## services\.comin\.flake_subdirectory
+## services\.comin\.flakeSubdirectory
 
 
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,6 +47,9 @@ func Read(path string) (config types.Configuration, err error) {
 	if config.StateFilepath == "" {
 		config.StateFilepath = filepath.Join(config.StateDir, "state.json")
 	}
+	if config.RepoDir == "" {
+		config.RepoDir = "."
+	}
 	logrus.Debugf("Config is '%#v'", config)
 	return
 }
@@ -54,6 +57,7 @@ func Read(path string) (config types.Configuration, err error) {
 func MkGitConfig(config types.Configuration) types.GitConfig {
 	return types.GitConfig{
 		Path:    filepath.Join(config.StateDir, "repository"),
+		Dir:     config.RepoDir,
 		Remotes: config.Remotes,
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -47,8 +47,8 @@ func Read(path string) (config types.Configuration, err error) {
 	if config.StateFilepath == "" {
 		config.StateFilepath = filepath.Join(config.StateDir, "state.json")
 	}
-	if config.RepoDir == "" {
-		config.RepoDir = "."
+	if config.FlakeSubdirectory == "" {
+		config.FlakeSubdirectory = "."
 	}
 	logrus.Debugf("Config is '%#v'", config)
 	return
@@ -57,7 +57,7 @@ func Read(path string) (config types.Configuration, err error) {
 func MkGitConfig(config types.Configuration) types.GitConfig {
 	return types.GitConfig{
 		Path:    filepath.Join(config.StateDir, "repository"),
-		Dir:     config.RepoDir,
+		Dir:     config.FlakeSubdirectory,
 		Remotes: config.Remotes,
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,7 @@ func TestConfig(t *testing.T) {
 		Hostname:      "machine",
 		StateDir:      "/var/lib/comin",
 		StateFilepath: "/var/lib/comin/state.json",
+		RepoDir:       ".",
 		Remotes: []types.Remote{
 			{
 				Name: "origin",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -9,10 +9,10 @@ import (
 func TestConfig(t *testing.T) {
 	configPath := "./configuration.yaml"
 	expected := types.Configuration{
-		Hostname:      "machine",
-		StateDir:      "/var/lib/comin",
-		StateFilepath: "/var/lib/comin/state.json",
-		RepoDir:       ".",
+		Hostname:          "machine",
+		StateDir:          "/var/lib/comin",
+		StateFilepath:     "/var/lib/comin/state.json",
+		FlakeSubdirectory: ".",
 		Remotes: []types.Remote{
 			{
 				Name: "origin",

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -24,7 +24,8 @@ type State struct {
 }
 
 type Manager struct {
-	repository repository.Repository
+	repository    repository.Repository
+	repositoryDir string
 	// FIXME: a generation should get a repository URL from the repository status
 	repositoryPath string
 	hostname       string
@@ -59,9 +60,10 @@ type Manager struct {
 	storage    store.Store
 }
 
-func New(r repository.Repository, s store.Store, p prometheus.Prometheus, path, hostname, machineId string) Manager {
+func New(r repository.Repository, s store.Store, p prometheus.Prometheus, path, dir, hostname, machineId string) Manager {
 	m := Manager{
 		repository:              r,
+		repositoryDir:           dir,
 		repositoryPath:          path,
 		hostname:                hostname,
 		machineId:               machineId,
@@ -173,7 +175,7 @@ func (m Manager) onRepositoryStatus(ctx context.Context, rs repository.Repositor
 		m.isRunning = false
 	} else {
 		// g.Stop(): this is required once we remove m.IsRunning
-		flakeUrl := fmt.Sprintf("git+file://%s?rev=%s", m.repositoryPath, m.repositoryStatus.SelectedCommitId)
+		flakeUrl := fmt.Sprintf("git+file://%s?dir=%s&rev=%s", m.repositoryPath, m.repositoryDir, m.repositoryStatus.SelectedCommitId)
 		m.generation = generation.New(rs, flakeUrl, m.hostname, m.machineId, m.evalFunc, m.buildFunc)
 		m.generation = m.generation.Eval(ctx)
 	}

--- a/internal/manager/manager_test.go
+++ b/internal/manager/manager_test.go
@@ -34,7 +34,7 @@ func (r *repositoryMock) FetchAndUpdate(ctx context.Context, remoteNames []strin
 func TestRun(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	r := newRepositoryMock()
-	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "")
+	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "", "")
 
 	evalDone := make(chan struct{})
 	buildDone := make(chan struct{})
@@ -95,7 +95,7 @@ func TestRun(t *testing.T) {
 func TestFetchBusy(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	r := newRepositoryMock()
-	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "machine-id")
+	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "", "machine-id")
 	go m.Run()
 
 	assert.Equal(t, State{}, m.GetState())
@@ -110,7 +110,7 @@ func TestFetchBusy(t *testing.T) {
 func TestRestartComin(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	r := newRepositoryMock()
-	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "machine-id")
+	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "", "machine-id")
 	dCh := make(chan deployment.DeploymentResult)
 	m.deploymentResultCh = dCh
 	isCominRestarted := false
@@ -132,7 +132,7 @@ func TestRestartComin(t *testing.T) {
 func TestOptionnalMachineId(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	r := newRepositoryMock()
-	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "the-test-machine-id")
+	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "", "the-test-machine-id")
 
 	evalDone := make(chan struct{})
 	buildDone := make(chan struct{})
@@ -164,7 +164,7 @@ func TestOptionnalMachineId(t *testing.T) {
 func TestIncorrectMachineId(t *testing.T) {
 	logrus.SetLevel(logrus.DebugLevel)
 	r := newRepositoryMock()
-	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "the-test-machine-id")
+	m := New(r, store.New("", 1, 1), prometheus.New(), "", "", "", "the-test-machine-id")
 
 	evalDone := make(chan struct{})
 	buildDone := make(chan struct{})

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -45,11 +45,11 @@ type HttpServer struct {
 }
 
 type Configuration struct {
-	Hostname      string     `yaml:"hostname"`
-	StateDir      string     `yaml:"state_dir"`
-	StateFilepath string     `yaml:"state_filepath"`
-	RepoDir       string     `yaml:"repo_dir"`
-	Remotes       []Remote   `yaml:"remotes"`
-	ApiServer     HttpServer `yaml:"api_server"`
-	Exporter      HttpServer `yaml:"exporter"`
+	Hostname          string     `yaml:"hostname"`
+	StateDir          string     `yaml:"state_dir"`
+	StateFilepath     string     `yaml:"state_filepath"`
+	FlakeSubdirectory string     `yaml:"flake_subdirectory"`
+	Remotes           []Remote   `yaml:"remotes"`
+	ApiServer         HttpServer `yaml:"api_server"`
+	Exporter          HttpServer `yaml:"exporter"`
 }

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -16,7 +16,9 @@ type Poller struct {
 
 type GitConfig struct {
 	// The repository Path
-	Path              string
+	Path string
+	// The directory in the repository
+	Dir               string
 	Remotes           []Remote
 	GpgPublicKeyPaths []string
 }
@@ -46,6 +48,7 @@ type Configuration struct {
 	Hostname      string     `yaml:"hostname"`
 	StateDir      string     `yaml:"state_dir"`
 	StateFilepath string     `yaml:"state_filepath"`
+	RepoDir       string     `yaml:"repo_dir"`
 	Remotes       []Remote   `yaml:"remotes"`
 	ApiServer     HttpServer `yaml:"api_server"`
 	Exporter      HttpServer `yaml:"exporter"`

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -18,7 +18,7 @@
           nixosConfigurations."<hostname>".config.system.build.toplevel
         '';
       };
-      flake_subdirectory = mkOption {
+      flakeSubdirectory = mkOption {
         type = str;
         default = ".";
         description = ''

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -18,6 +18,13 @@
           nixosConfigurations."<hostname>".config.system.build.toplevel
         '';
       };
+      repo_dir = mkOption {
+        type = str;
+        default = ".";
+        description = ''
+          Subdirectory in the repository, containing flake.nix.
+        '';
+      };
       exporter = mkOption {
         description = "Options for the Prometheus exporter.";
         default = {};

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -18,7 +18,7 @@
           nixosConfigurations."<hostname>".config.system.build.toplevel
         '';
       };
-      repo_dir = mkOption {
+      flake_subdirectory = mkOption {
         type = str;
         default = ".";
         description = ''

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -4,6 +4,7 @@ overlay: { config, pkgs, lib, ... }: let
   cominConfig = {
     hostname = cfg.services.comin.hostname;
     state_dir = "/var/lib/comin";
+    repo_dir = cfg.services.comin.repo_dir;
     remotes = cfg.services.comin.remotes;
     exporter = {
       listen_address = cfg.services.comin.exporter.listen_address;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,7 +5,7 @@ let
   cominConfig = {
     hostname = cfg.services.comin.hostname;
     state_dir = "/var/lib/comin";
-    flake_subdirectory = cfg.services.comin.flake_subdirectory;
+    flake_subdirectory = cfg.services.comin.flakeSubdirectory;
     remotes = cfg.services.comin.remotes;
     exporter = {
       listen_address = cfg.services.comin.exporter.listen_address;

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,10 +1,11 @@
-overlay: { config, pkgs, lib, ... }: let
+overlay: { config, pkgs, lib, ... }:
+let
   cfg = config;
   yaml = pkgs.formats.yaml { };
   cominConfig = {
     hostname = cfg.services.comin.hostname;
     state_dir = "/var/lib/comin";
-    repo_dir = cfg.services.comin.repo_dir;
+    flake_subdirectory = cfg.services.comin.flake_subdirectory;
     remotes = cfg.services.comin.remotes;
     exporter = {
       listen_address = cfg.services.comin.exporter.listen_address;
@@ -30,7 +31,7 @@ in {
           + (lib.optionalString cfg.services.comin.debug "--debug ")
           + " run "
           + "--config ${cominConfigYaml}";
-          Restart = "always";
+        Restart = "always";
       };
     };
   };


### PR DESCRIPTION
This PR adds support for `flake.nix` files not stored in the root of the repository.

I'm aware, that my use-case may be a little bit extra-ordinary, but I maintain one big, gitops monorepo with bunch of stuff separated in different subdirectories (i.e. k8s manifests in `k8s`, nix flakes in `nix` etc.). This PR will add support of such cases, by providing option to set up custom subdirectory, while still maintaing compatibility (as the param defaults to `"."`).

I also tested this branch on my local machine, and no issues so far.