### PR TITLE
Trim whitespaces from access token

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"gopkg.in/yaml.v2"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 func Read(path string) (config types.Configuration, err error) {
@@ -25,7 +26,7 @@ func Read(path string) (config types.Configuration, err error) {
 			if err != nil {
 				return config, err
 			}
-			config.Remotes[i].Auth.AccessToken = string(content)
+			config.Remotes[i].Auth.AccessToken = strings.TrimSpace(string(content))
 		}
 		if remote.Timeout == 0 {
 			config.Remotes[i].Timeout = 300


### PR DESCRIPTION
Some editors add a newline at the end of a file automatically, which currently is processed by comin.

This makes authentication at the remote fail.

As there are no newlines or other whitespace characters that are relevant, doing an input sanitization here makes sense.

Fixes https://github.com/nlewo/comin/issues/57 and probably also https://github.com/nlewo/comin/issues/38 (as Forgejo does not have a requirement for a specific username, when using an access token).