### PR TITLE
don't re-instantiate nixpkgs in flake and module

### DIFF
--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -16,6 +16,24 @@ boolean
 
 
 
+## services\.comin\.package
+
+
+
+The comin package to use\.
+
+
+
+*Type:*
+null or package
+
+
+
+*Default:*
+` "pkgs.comin or comin.packages.\${system}.default or null" `
+
+
+
 ## services\.comin\.debug
 
 Whether to run comin in debug mode\. Be careful, secrets are shown!\.

--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,18 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717281328,
-        "narHash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
-        "path": "/nix/store/f3rv70nrmkfya581f1j2z9a6yx0b83np-source",
-        "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1",
-        "type": "path"
+        "lastModified": 1738574474,
+        "narHash": "sha256-rvyfF49e/k6vkrRTV4ILrWd92W+nmBDfRYZgctOyolQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fecfeb86328381268e29e998ddd3ebc70bbd7f7c",
+        "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
+        "owner": "NixOS",
+        "ref": "nixos-24.11",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -5,66 +5,27 @@
   let
     systems = [ "aarch64-linux" "x86_64-linux" ];
     forAllSystems = nixpkgs.lib.genAttrs systems;
-    nixpkgsFor = forAllSystems (system: import nixpkgs {
-      inherit system;
-      overlays = [ self.overlays.default ];
-    });
+    nixpkgsFor = forAllSystems (system: nixpkgs.legacyPackages.${system});
     optionsDocFor = forAllSystems (system:
       import ./nix/module-options-doc.nix (nixpkgsFor."${system}")
     );
   in {
-    overlays.default = final: prev: let
-      # - safe.directory: this is to allow comin to fetch local repositories belonging
-      #   to other users. Otherwise, comin fails with:
-      #   Pull from remote 'local' failed: unknown error: fatal: detected dubious ownership in repository
-      # - core.hooksPath: to avoid Git executing hooks from a repository belonging to another user
-      gitConfigFile = final.writeTextFile {
-        name = "git.config";
-        text = ''
-          [safe]
-             directory = *
-          [core]
-             hooksPath = /dev/null
-        '';
-      };
-    in {
-      comin = final.buildGoModule rec {
-        pname = "comin";
-        version = "0.6.0";
-        nativeCheckInputs = [ final.git ];
-        src = final.lib.fileset.toSource {
-          root = ./.;
-          fileset = final.lib.fileset.unions [
-            ./cmd
-            ./internal
-            ./go.mod
-            ./go.sum
-            ./main.go
-          ];
-        };
-        vendorHash = "sha256-VP8y/iSBIXZFfSmhHsXkp6RxP+2DovX3PbEDtMUMyYE=";
-        ldflags = [
-          "-X github.com/nlewo/comin/cmd.version=${version}"
-        ];
-        buildInputs = [ final.makeWrapper ];
-        postInstall = ''
-          # This is because Nix needs Git at runtime by the go-git library
-          wrapProgram $out/bin/comin --set GIT_CONFIG_SYSTEM ${gitConfigFile} --prefix PATH : ${final.git}/bin
-        '';
-      };
+    overlays.default = final: prev: {
+      comin = final.callPackage ./nix/package.nix { };
     };
 
     packages = forAllSystems (system: {
-      default = nixpkgsFor."${system}".comin;
+      comin = nixpkgsFor."${system}".callPackage ./nix/package.nix { };
+      default = self.packages."${system}".comin;
       generate-module-options = optionsDocFor."${system}".optionsDocCommonMarkGenerator;
     });
     checks = forAllSystems (system: {
       module-options-doc = optionsDocFor."${system}".checkOptionsDocCommonMark;
       # I don't understand why nix flake check does't build packages.default
-      package = nixpkgsFor."${system}".comin;
+      package = self.packages."${system}".comin;
     });
 
-    nixosModules.comin = import ./nix/module.nix self.overlays.default;
+    nixosModules.comin = import ./nix/module.nix self;
     devShells.x86_64-linux.default = let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   description = "Comin - GitOps for NixOS Machines";
 
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
+
   outputs = { self, nixpkgs }:
   let
     systems = [ "aarch64-linux" "x86_64-linux" ];
@@ -25,7 +27,7 @@
       package = self.packages."${system}".comin;
     });
 
-    nixosModules.comin = import ./nix/module.nix self;
+    nixosModules.comin = nixpkgs.lib.modules.importApply ./nix/module.nix { inherit self; };
     devShells.x86_64-linux.default = let
       pkgs = nixpkgs.legacyPackages.x86_64-linux;
     in pkgs.mkShell {

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -8,6 +8,9 @@
           Whether to run the comin service.
         '';
       };
+      package = lib.mkPackageOption pkgs "comin" { nullable = true; } // {
+        defaultText = "pkgs.comin or comin.packages.\${system}.default or null";
+      };
       hostname = mkOption {
         type = str;
         default = config.networking.hostName;

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -50,7 +50,7 @@
             openFirewall = mkOption {
               type = types.bool;
               default = false;
-              description = lib.mdDoc ''
+              description = ''
                 Open port in firewall for incoming connections to the Prometheus exporter.
               '';
             };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -37,7 +37,7 @@ in {
       restartIfChanged = false;
       serviceConfig = {
         ExecStart =
-          "${package}/bin/comin "
+          (lib.getExe package)
           + (lib.optionalString cfg.services.comin.debug "--debug ")
           + " run "
           + "--config ${cominConfigYaml}";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -45,4 +45,8 @@ buildGoModule rec {
     # This is because Nix needs Git at runtime by the go-git library
     wrapProgram $out/bin/comin --set GIT_CONFIG_SYSTEM ${gitConfigFile} --prefix PATH : ${git}/bin
   '';
+
+  meta = {
+    mainProgram = "comin";
+  };
 }

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,48 @@
+{
+  lib,
+  buildGoModule,
+  git,
+  makeWrapper,
+  writeTextFile,
+}:
+
+let
+  # - safe.directory: this is to allow comin to fetch local repositories belonging
+  #   to other users. Otherwise, comin fails with:
+  #   Pull from remote 'local' failed: unknown error: fatal: detected dubious ownership in repository
+  # - core.hooksPath: to avoid Git executing hooks from a repository belonging to another user
+  gitConfigFile = writeTextFile {
+    name = "git.config";
+    text = ''
+      [safe]
+         directory = *
+      [core]
+         hooksPath = /dev/null
+    '';
+  };
+in
+
+buildGoModule rec {
+  pname = "comin";
+  version = "0.6.0";
+  nativeCheckInputs = [ git ];
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../cmd
+      ../internal
+      ../go.mod
+      ../go.sum
+      ../main.go
+    ];
+  };
+  vendorHash = "sha256-VP8y/iSBIXZFfSmhHsXkp6RxP+2DovX3PbEDtMUMyYE=";
+  ldflags = [
+    "-X github.com/nlewo/comin/cmd.version=${version}"
+  ];
+  buildInputs = [ makeWrapper ];
+  postInstall = ''
+    # This is because Nix needs Git at runtime by the go-git library
+    wrapProgram $out/bin/comin --set GIT_CONFIG_SYSTEM ${gitConfigFile} --prefix PATH : ${git}/bin
+  '';
+}


### PR DESCRIPTION
This is expensive on evaluation, but can be easily avoided here as we aren't using unfree packages or special configurations 

See https://zimbatm.com/notes/1000-instances-of-nixpkgs

The only systems this will affect are those not listed [here](https://github.com/nlewo/comin/blob/773f6141a95f0538f3f8e687da037659bf38bd40/flake.nix#L6), as the overlay will no longer be automatically applied and an assertion will be triggered. They will need to add `nixpkgs.overlays = [ comin.overlays.default ]` to their configuration; users on other systems will have overlayed packages used by default as well
