### PR TITLE
deconstruct arguments applied to module

### DIFF
--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -149,7 +149,7 @@ A list of GPG public key file paths\. Each of this file should contains an armor
 
 
 *Type:*
-list of Concatenated string
+list of string
 
 
 

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -171,7 +171,7 @@
       };
       gpgPublicKeyPaths = mkOption {
         description = "A list of GPG public key file paths. Each of this file should contains an armored GPG key.";
-        type = listOf string;
+        type = listOf str;
         default = [];
       };
     };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,4 +1,4 @@
-self: { config, pkgs, lib, ... }:
+{ self }: { config, pkgs, lib, ... }:
 let
   cfg = config;
   yaml = pkgs.formats.yaml { };


### PR DESCRIPTION
Fixes evaluate errors from https://github.com/nlewo/comin/pull/67 when `cfg.package` is not explicitly set or the overlay is not used

Sorry!
