### PR TITLE
Add missing space in front of systemd service debug argument

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -39,7 +39,7 @@ in {
       serviceConfig = {
         ExecStart =
           (lib.getExe package)
-          + (lib.optionalString cfg.services.comin.debug "--debug ")
+          + (lib.optionalString cfg.services.comin.debug " --debug ")
           + " run "
           + "--config ${cominConfigYaml}";
         Restart = "always";


### PR DESCRIPTION
When set `debug = true` option a error occurs because of missing space in front of the debug argument in the systemd-unit definition.

```
Mar 22 16:43:48 cahir systemd[1]: Started comin.service.
Mar 22 16:43:48 cahir (n--debug)[137004]: comin.service: Unable to locate executable '/nix/store/9g4qw0r0yrx1n9k2cw9329vq2wrj07kr-comin-0.6.0/bin/comin--debug': No such file or directory
Mar 22 16:43:48 cahir (n--debug)[137004]: comin.service: Failed at step EXEC spawning /nix/store/9g4qw0r0yrx1n9k2cw9329vq2wrj07kr-comin-0.6.0/bin/comin--debug: No such file or directory
Mar 22 16:43:48 cahir systemd[1]: comin.service: Main process exited, code=exited, status=203/EXEC
Mar 22 16:43:48 cahir systemd[1]: comin.service: Failed with result 'exit-code'.
Mar 22 16:43:48 cahir systemd[1]: comin.service: Scheduled restart job, restart counter is at 5.
Mar 22 16:43:48 cahir systemd[1]: comin.service: Start request repeated too quickly.
Mar 22 16:43:48 cahir systemd[1]: comin.service: Failed with result 'exit-code'.
Mar 22 16:43:48 cahir systemd[1]: Failed to start comin.service.
```
