### PR TITLE
Expose the comin.postDeploymentCommand option

### DIFF
--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -205,6 +205,37 @@ null or string
 
 
 
+## services\.comin\.postDeploymentCommand
+
+
+
+A path to a script executed after each
+deployment\. comin provides to the script the following
+environment variables: ` COMIN_GIT_SHA `, ` COMIN_GIT_REF `,
+` COMIN_GIT_MSG `, ` COMIN_HOSTNAME `, ` COMIN_FLAKE_URL `,
+` COMIN_GENERATION `, ` COMIN_STATUS ` and ` COMIN_ERROR_MSG `\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+` null `
+
+
+
+*Example:*
+
+```
+pkgs.writers.writeBash "post" "echo $COMIN_GIT_SHA";
+
+```
+
+
+
 ## services\.comin\.remotes
 
 

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -174,6 +174,18 @@
         type = listOf str;
         default = [];
       };
+      postDeploymentCommand = mkOption {
+        description = "A path to a script executed after each
+        deployment. comin provides to the script the following
+        environment variables: `COMIN_GIT_SHA`, `COMIN_GIT_REF`,
+        `COMIN_GIT_MSG`, `COMIN_HOSTNAME`, `COMIN_FLAKE_URL`,
+        `COMIN_GENERATION`, `COMIN_STATUS` and `COMIN_ERROR_MSG`.";
+        type = nullOr path;
+        default = null;
+        example = lib.literalExpression ''
+          pkgs.writers.writeBash "post" "echo $COMIN_GIT_SHA";
+        '';
+      };
     };
   };
 }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -12,7 +12,10 @@ let
       port = cfg.services.comin.exporter.port;
     };
     gpg_public_key_paths = cfg.services.comin.gpgPublicKeyPaths;
-  };
+  } // (
+    lib.optionalAttrs (cfg.services.comin.postDeploymentCommand != null)
+      { post_deployment_command = cfg.services.comin.postDeploymentCommand; }
+  );
   cominConfigYaml = yaml.generate "comin.yaml" cominConfig;
 
   inherit (pkgs.stdenv.hostPlatform) system;


### PR DESCRIPTION
We have a post deployment hook feature... which was unfortunately not exposed to the user in the comin module.

cc @tcurdt 

Option documentation is rendered there: https://github.com/nlewo/comin/blob/option-post/docs/generated-module-options.md#servicescominpostdeploymentcommand