### PR TITLE
Exit to restart

### DIFF
--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -64,7 +64,8 @@ func runNixCommand(args []string, stdout, stderr io.Writer) (err error) {
 func showDerivation(ctx context.Context, flakeUrl, hostname string) (drvPath string, outPath string, err error) {
 	installable := fmt.Sprintf("%s#nixosConfigurations.%s.config.system.build.toplevel", flakeUrl, hostname)
 	args := []string{
-		"show-derivation",
+		"derivation",
+		"show",
 		installable,
 		"-L",
 		"--show-trace",

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -3,23 +3,8 @@ package utils
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
-
-	"github.com/sirupsen/logrus"
 )
-
-func CominServiceRestart() error {
-	logrus.Infof("The comin.service unit file changed. Comin systemd service is now restarted...")
-	logrus.Infof("Restarting the systemd comin.service: 'systemctl restart --no-block comin.service'")
-	cmd := exec.Command("systemctl", "restart", "--no-block", "comin.service")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("command 'systemctl restart --no-block comin.service' fails with %s", err)
-	}
-	return nil
-}
 
 func FormatCommitMsg(msg string) string {
 	split := strings.Split(msg, "\n")


### PR DESCRIPTION
As suggest by @multivac61 in https://github.com/nlewo/comin/pull/89, instead of explicitly restart comin, we could just stop it and let systemd restarting it.

Looks like it works well:
```
Jun 19 23:31:35 tilia comin[1051060]: time="2025-06-19T23:31:35+02:00" level=info msg="manager: comin needs to be restarted"
Jun 19 23:31:35 tilia comin[1051060]: time="2025-06-19T23:31:35+02:00" level=info msg="manager: exiting comin to let the serice manager restarting it"
Jun 19 23:31:35 tilia systemd[1]: comin.service: Deactivated successfully.
Jun 19 23:31:35 tilia systemd[1]: comin.service: Consumed 7min 3.963s CPU time, 1.9G memory peak, 622.4M read from disk, 488.5M written to disk, 1K incoming IP traffic, 73.3K outgoing IP traffic.
Jun 19 23:31:35 tilia systemd[1]: comin.service: Scheduled restart job, restart counter is at 1.
Jun 19 23:31:35 tilia systemd[1]: Started comin.service.

```