### PR TITLE
Skip the build

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -82,7 +82,7 @@ var runCmd = &cobra.Command{
 		sched := scheduler.New()
 		sched.FetchRemotes(fetcher, cfg.Remotes)
 
-		builder := builder.New(store, gitConfig.Path, gitConfig.Dir, cfg.Hostname, 30*time.Minute, executor.Eval, 30*time.Minute, executor.Build)
+		builder := builder.New(store, executor, gitConfig.Path, gitConfig.Dir, cfg.Hostname, 30*time.Minute, 30*time.Minute)
 		deployer := deployer.New(executor.Deploy, lastDeployment, cfg.PostDeploymentCommand)
 
 		manager := manager.New(store, metrics, sched, fetcher, builder, deployer, machineId, executor)

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -6,6 +6,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+type EvalFunc func(ctx context.Context, flakeUrl string, hostname string) (drvPath string, outPath string, machineId string, err error)
+type BuildFunc func(ctx context.Context, drvPath string) error
+
 // Executor contains the function used by comin to actually do actions
 // on the host. This allows us to abstract the way Nix expression are
 // evaluated, built and deployed. This could be for instance used by a

--- a/internal/executor/executor.go
+++ b/internal/executor/executor.go
@@ -20,6 +20,9 @@ type Executor interface {
 	Deploy(ctx context.Context, outPath, operation string) (needToRestartComin bool, profilePath string, err error)
 	NeedToReboot() bool
 	ReadMachineId() (string, error)
+	// IsStorePathExist returns true if a storepath exists. This
+	// is used to detect if a build will be required or not.
+	IsStorePathExist(string) bool
 }
 
 func NewNixOS() (e Executor, err error) {

--- a/internal/executor/nix.go
+++ b/internal/executor/nix.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 
 	"github.com/nlewo/comin/internal/utils"
@@ -34,6 +35,13 @@ func (n *NixLocal) NeedToReboot() bool {
 		return false
 	}
 	return utils.NeedToRebootLinux()
+}
+
+func (n *NixLocal) IsStorePathExist(storePath string) bool {
+	if _, err := os.Stat(storePath); errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	return true
 }
 
 func (n *NixLocal) ShowDerivation(ctx context.Context, flakeUrl, hostname string) (drvPath string, outPath string, err error) {

--- a/internal/store/generation.go
+++ b/internal/store/generation.go
@@ -246,7 +246,7 @@ func (s *Store) GenerationBuildFinished(uuid uuid.UUID, buildErr error) error {
 			}
 		}
 		if err := os.Symlink(g.OutPath, s.generationGcRoot); err != nil {
-			logrus.Error(err)
+			logrus.Errorf("Could not create the gcroot symlink for the generation %s: %s", g.UUID.String(), err)
 		}
 	} else {
 		g.BuildStatus = BuildFailed


### PR DESCRIPTION
The builder doesn't need to be started when the output is already in the local nix store.
This is mainly to prepare the next feature which consists on asking user confirmation before build/deploy.