### PR TITLE
Set deployment_info metric on start

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -70,6 +70,7 @@ var runCmd = &cobra.Command{
 		if ok, ld := store.LastDeployment(); ok {
 			mainCommitId = ld.Generation.MainCommitId
 			lastDeployment = &ld
+			metrics.SetDeploymentInfo(ld.Generation.SelectedCommitId, storePkg.StatusToString(ld.Status))
 		}
 		repository, err := repository.New(gitConfig, mainCommitId, metrics)
 		if err != nil {


### PR DESCRIPTION
Currently, the comin_deployment_info disappears on a comin daemon restart until a new deployment starts.