### PR TITLE
feat: `impure` option for passing `--impure` to Nix commands

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,6 +35,12 @@ var runCmd = &cobra.Command{
 
 		gitConfig := config.MkGitConfig(cfg)
 
+		// Set impure flag if enabled in configuration
+		if cfg.Impure {
+			logrus.Info("executor: enabling impure evaluation")
+			executorPkg.SetImpure(true)
+		}
+
 		executor, err := executorPkg.NewNixOS()
 		if runtime.GOOS == "darwin" {
 			executor, err = executorPkg.NewNixDarwin()

--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -180,6 +180,25 @@ string
 
 
 
+## services\.comin\.impure
+
+
+
+Whether to enable impure evaluation for Nix commands\.
+When enabled, Nix commands will be executed with the --impure flag\.
+
+
+
+*Type:*
+boolean
+
+
+
+*Default:*
+` false `
+
+
+
 ## services\.comin\.machineId
 
 

--- a/internal/executor/nix.go
+++ b/internal/executor/nix.go
@@ -78,9 +78,14 @@ func (n *NixLocal) List(flakeUrl string) (hosts []string, err error) {
 	args := []string{
 		"flake",
 		"show",
+	}
+	if impure {
+		args = append(args, "--impure")
+	}
+	args = append(args,
 		"--json",
 		flakeUrl,
-	}
+	)
 	var stdout bytes.Buffer
 	err = runNixCommand(context.Background(), args, &stdout, os.Stderr)
 	if err != nil {

--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -23,8 +23,11 @@ func getExpectedMachineId(ctx context.Context, path, hostname, configurationAttr
 	args := []string{
 		"eval",
 		expr,
-		"--json",
 	}
+	if impure {
+		args = append(args, "--impure")
+	}
+	args = append(args, "--json")
 	var stdout bytes.Buffer
 	err = runNixCommand(ctx, args, &stdout, os.Stderr)
 	if err != nil {
@@ -43,6 +46,14 @@ func getExpectedMachineId(ctx context.Context, path, hostname, configurationAttr
 		machineId = ""
 	}
 	return
+}
+
+// Store impure flag from configuration
+var impure bool
+
+// SetImpure sets whether to enable impure evaluation for nix commands
+func SetImpure(enabled bool) {
+	impure = enabled
 }
 
 func runNixCommand(ctx context.Context, args []string, stdout, stderr io.Writer) (err error) {
@@ -65,10 +76,15 @@ func showDerivation(ctx context.Context, flakeUrl, hostname, configurationAttr s
 	args := []string{
 		"derivation",
 		"show",
+	}
+	if impure {
+		args = append(args, "--impure")
+	}
+	args = append(args,
 		installable,
 		"-L",
 		"--show-trace",
-	}
+	)
 	var stdout bytes.Buffer
 	err = runNixCommand(ctx, args, &stdout, os.Stderr)
 	if err != nil {
@@ -94,9 +110,15 @@ func showDerivation(ctx context.Context, flakeUrl, hostname, configurationAttr s
 func build(ctx context.Context, drvPath string) (err error) {
 	args := []string{
 		"build",
+	}
+	if impure {
+		args = append(args, "--impure")
+	}
+	args = append(args,
 		fmt.Sprintf("%s^*", drvPath),
 		"-L",
-		"--no-link"}
+		"--no-link",
+	)
 	err = runNixCommand(ctx, args, os.Stdout, os.Stderr)
 	if err != nil {
 		return

--- a/internal/executor/utils_test.go
+++ b/internal/executor/utils_test.go
@@ -186,3 +186,31 @@ func TestDeployFunctions(t *testing.T) {
 		})
 	}
 }
+
+func TestSetImpure(t *testing.T) {
+	originalImpure := impure
+	defer func() {
+		impure = originalImpure
+	}()
+
+	tests := []struct {
+		name    string
+		enabled bool
+	}{
+		{
+			name:    "Impure disabled",
+			enabled: false,
+		},
+		{
+			name:    "Impure enabled",
+			enabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetImpure(tt.enabled)
+			assert.Equal(t, tt.enabled, impure)
+		})
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -49,6 +49,7 @@ type Configuration struct {
 	StateDir              string     `yaml:"state_dir"`
 	StateFilepath         string     `yaml:"state_filepath"`
 	FlakeSubdirectory     string     `yaml:"flake_subdirectory"`
+	Impure                bool       `yaml:"impure"`
 	Remotes               []Remote   `yaml:"remotes"`
 	ApiServer             HttpServer `yaml:"api_server"`
 	Exporter              HttpServer `yaml:"exporter"`

--- a/nix/comin-config.nix
+++ b/nix/comin-config.nix
@@ -16,6 +16,9 @@ in rec {
   } // (
     lib.optionalAttrs (cfg.services.comin.postDeploymentCommand != null)
       { post_deployment_command = cfg.services.comin.postDeploymentCommand; }
+  ) // (
+    lib.optionalAttrs (cfg.services.comin.impure)
+      { impure = cfg.services.comin.impure; }
   );
   cominConfigYaml = yaml.generate "comin.yaml" cominConfig;
 }

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -29,6 +29,14 @@
           Subdirectory in the repository, containing flake.nix.
         '';
       };
+      impure = mkOption {
+        type = bool;
+        default = false;
+        description = ''
+          Whether to enable impure evaluation for Nix commands.
+          When enabled, Nix commands will be executed with the --impure flag.
+        '';
+      };
       exporter = mkOption {
         description = "Options for the Prometheus exporter.";
         default = {};


### PR DESCRIPTION
Adds a new `impure` configuration option that allows users to pass `--impure` to appropriate Nix commands. Useful for cases like including runtime metadata, outside of the flake, in a system derivation.

---

Hey @nlewo 👋 thanks for creating and sharing comin with the world! Hoping this is a feature you'd be happy to accept.
I needed impure evaluation for how I'm approaching the provisioning of my systems: I wanted a way of passing through metadata from my provisioning source (Pulumi) to my NixOS configuration. In my case, I template EC2 userdata, creating an `/etc/nixos/metadata.json` file with interpolated values from the Pulumi program. This then gets read in by a NixOS module using `builtins.fromJSON (builtins.readFile "/etc/nixos/metadata.json")` so i can then use it throughout configuration, referring to values like `config.metadata.foo`.

Of course, since `/etc/nixos/metadata.json` is outside my flake, I needed the `--impure` flag. I've been using this over the past week and it works nicely :) Let me know what you think