### PR TITLE
darwin: Ensure comin service is running after activation

### DIFF
--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -50,6 +50,12 @@ in {
       if [ -f /Library/LaunchDaemons/com.github.nlewo.comin.plist ]; then
         # Ensure service is loaded but don't restart during activation
         /bin/launchctl load -w /Library/LaunchDaemons/com.github.nlewo.comin.plist 2>/dev/null || true
+        
+        # Check if the service is actually running, if not start it
+        if ! /bin/launchctl list | grep -q "com.github.nlewo.comin"; then
+          echo "Comin service not running, starting it..."
+          /bin/launchctl start com.github.nlewo.comin || true
+        fi
       fi
     '';
   };


### PR DESCRIPTION
The activation script now checks if the comin service is actually running after loading the plist file, and starts it if necessary. This prevents "connection refused" errors after configuration switches.

Fixes an issues I observed on my mac system when the comin cli would sometimes not be able to call e.g., `comin status`