### PR TITLE
Fix darwin module evaluation error

### DIFF
--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -32,7 +32,7 @@ in {
         StandardErrorPath = "/var/log/comin.log";
         StandardOutPath = "/var/log/comin.log";
         EnvironmentVariables = {
-          PATH = lib.makeBinPath [ config.nix.package pkgs.git pkgs.ssh ];
+          PATH = lib.makeBinPath [ config.nix.package pkgs.git pkgs.openssh ];
         };
       };
     };


### PR DESCRIPTION
Fix the evaluation error introduced in https://github.com/nlewo/comin/pull/116:

```
error: attribute 'ssh' missing
at /nix/store/dz29q1cnmqjgydlnk1vwzix3c8il0mzn-source/nix/darwin-module.nix:35:64:
   34|         EnvironmentVariables = {
   35|           PATH = lib.makeBinPath [ config.nix.package pkgs.git pkgs.ssh ];
     |                                                                ^
   36|         };
Did you mean one of assh, bsh, esh, ksh or lsh?
```