### PR TITLE
Fix darwin daemon startup order on macOS restart

### DIFF
--- a/nix/darwin-module.nix
+++ b/nix/darwin-module.nix
@@ -18,14 +18,14 @@ in {
     environment.systemPackages = [ package ];
     services.comin.package = lib.mkDefault pkgs.comin or self.packages.${system}.comin or null;
     launchd.daemons.comin = {
+      command = lib.concatStringsSep " " ([
+        (lib.getExe package)
+      ] ++ (lib.optionals cfg.services.comin.debug [ "--debug" ]) ++ [
+        "run"
+        "--config"
+        "${cominConfigYaml}"
+      ]);
       serviceConfig = {
-        ProgramArguments = [
-          (lib.getExe package)
-        ] ++ (lib.optionals cfg.services.comin.debug [ "--debug" ]) ++ [
-          "run"
-          "--config"
-          "${cominConfigYaml}"
-        ];
         Label = "com.github.nlewo.comin";
         KeepAlive = true;
         RunAtLoad = true;


### PR DESCRIPTION
On macOS restart, the comin daemon fails to start because `/nix/store` is not mounted yet when launchd attempts to start the service with `RunAtLoad = true`. The error looks like:

```
Could not find and/or execute program specified by service: 2: No such file or directory: /nix/store/.../bin/comin
```

This PR fixes the issue by replacing `ProgramArguments` with `command` in the launchd configuration. In nix-darwin, using `command` automatically wraps execution with `/bin/wait4path /nix/store &&`, ensuring the Nix store is available before the daemon starts.

reference: https://github.com/nix-darwin/nix-darwin/blob/7e22bf538aa3e0937effcb1cee73d5f1bcc26f79/modules/launchd/default.nix#L90-L94