### PR TITLE
fix: handle Nix 2.32+ output path format change

### DIFF
--- a/internal/executor/utils.go
+++ b/internal/executor/utils.go
@@ -84,13 +84,18 @@ func showDerivation(ctx context.Context, flakeUrl, hostname, configurationAttr s
 	for key := range output {
 		keys = append(keys, key)
 	}
-	drvPath = keys[0]
+	drvKey := keys[0]
+	outPath = output[drvKey].Outputs.Out.Path
 	// derivation jsons do not contain store directory anymore since nix 2.32
 	// see https://nix.dev/manual/nix/2.32/release-notes/rl-2.32.html#:~:text=derivation%20json%20format%20now%20uses%20store%20path%20basenames%20only
-	if !strings.HasPrefix(drvPath, "/nix/store/") {
-		drvPath = "/nix/store/" + drvPath
+	if !strings.HasPrefix(drvKey, "/nix/store/") {
+		drvPath = "/nix/store/" + drvKey
+	} else {
+		drvPath = drvKey
 	}
-	outPath = output[drvPath].Outputs.Out.Path
+	if !strings.HasPrefix(outPath, "/nix/store/") && outPath != "" {
+		outPath = "/nix/store/" + outPath
+	}
 	logrus.Infof("nix: the derivation path is %s", drvPath)
 	logrus.Infof("nix: the output path is %s", outPath)
 	return


### PR DESCRIPTION
Nix 2.32 changed `nix derivation show` to output paths without the /nix/store/ prefix. The previous fix only handled the derivation path key but used the modified key to access the map, resulting in an empty output path.

This fix:
- Uses the original key to access the map before modifying it
- Prepends /nix/store/ to the output path as well

See: https://nix.dev/manual/nix/2.32/release-notes/rl-2.32.html