### PR TITLE
desktop: restart on faliure

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -44,6 +44,9 @@ in
       path = [ pkgs.libnotify ];
       serviceConfig = {
         ExecStart = ''${lib.getExe package} desktop --title "${cfg.services.comin.desktop.title}"'';
+        # comin fails when started  before the desktop notification service
+        Restart="on-failure";
+        RestartSec=5;
       };
     };
 


### PR DESCRIPTION
This makes the desktop service restart comin on failure.\
There is a high chance that the comin desktop service starts before the notification service on a system (such as mine), causing it to fail and not try again with the following error:
```log
panic: beeep: dbus: unexpected EOF; notify-send: exit status 1; kdialog: exec: "kdialog": executable file no>
goroutine 1 [running]:
github.com/nlewo/comin/cmd.init.func8(0x17e1fe0, {0x1f1807e0c780?, 0x4?, 0xf0cbf5?})
        github.com/nlewo/comin/cmd/desktop.go:31 +0x1f6
github.com/spf13/cobra.(*Command).execute(0x17e1fe0, {0x1f1807e0c760, 0x2, 0x2})
        github.com/spf13/cobra@v1.8.0/command.go:987 +0xb1b
github.com/spf13/cobra.(*Command).ExecuteC(0x17e2b60)
        github.com/spf13/cobra@v1.8.0/command.go:1115 +0x44f
github.com/spf13/cobra.(*Command).Execute(...)
        github.com/spf13/cobra@v1.8.0/command.go:1039
github.com/nlewo/comin/cmd.Execute()
        github.com/nlewo/comin/cmd/root.go:26 +0x1a
main.main()
        github.com/nlewo/comin/main.go:9 +0xf

```

The service auto-restarting is already enabled for the system comin service, just not the user desktop service.