### PR TITLE
Use a bare local repository

### DIFF
--- a/internal/repository/git.go
+++ b/internal/repository/git.go
@@ -10,7 +10,6 @@ import (
 	gitConfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/nlewo/comin/internal/types"
 	"github.com/sirupsen/logrus"
@@ -97,60 +96,6 @@ func getHeadFromRemoteAndBranch(r repository, remoteName, branchName, currentMai
 	return *head, commitObject.Message, nil
 }
 
-func hardReset(r repository, newHead plumbing.Hash, auth transport.AuthMethod) error {
-	var w *git.Worktree
-	w, err := r.Repository.Worktree()
-	if err != nil {
-		return fmt.Errorf("failed to get the worktree")
-	}
-	err = w.Checkout(&git.CheckoutOptions{
-		Hash:  newHead,
-		Force: true,
-	})
-	if err != nil {
-		return fmt.Errorf("git reset --hard %s fails: '%s'", newHead, err)
-	}
-	if r.GitConfig.Submodules {
-		if err := updateSubmodules(w, auth); err != nil {
-			return fmt.Errorf("failed to update submodules: %s", err)
-		}
-	}
-	return nil
-}
-
-func updateSubmodules(w *git.Worktree, auth transport.AuthMethod) error {
-	submodules, err := w.Submodules()
-	if err != nil {
-		return err
-	}
-	for _, sub := range submodules {
-		logrus.Debugf("Updating submodule %s", sub.Config().Name)
-		err := sub.Update(&git.SubmoduleUpdateOptions{
-			Init:              true,
-			RecurseSubmodules: git.DefaultSubmoduleRecursionDepth,
-			Auth:              auth,
-		})
-		if err != nil {
-			return fmt.Errorf("failed to update submodule %s: %s", sub.Config().Name, err)
-		}
-	}
-	return nil
-}
-
-// getAuthForRemote returns the transport.AuthMethod for the named remote, or nil if
-// no authentication is configured.
-func getAuthForRemote(config types.GitConfig, remoteName string) transport.AuthMethod {
-	for _, remote := range config.Remotes {
-		if remote.Name == remoteName && remote.Auth.AccessToken != "" {
-			return &http.BasicAuth{
-				Username: remote.Auth.Username,
-				Password: remote.Auth.AccessToken,
-			}
-		}
-	}
-	return nil
-}
-
 // fetch fetches the config.Remote
 func fetch(r repository, remote types.Remote) (err error) {
 	logrus.Debugf("Fetching remote '%s'", remote.Name)
@@ -204,7 +149,7 @@ func isAncestor(r *git.Repository, base, top plumbing.Hash) (found bool, err err
 }
 
 func repositoryOpen(config types.GitConfig) (r *git.Repository, err error) {
-	r, err = git.PlainInit(config.Path, false)
+	r, err = git.PlainInit(config.Path, true)
 	if err != nil {
 		r, err = git.PlainOpen(config.Path)
 		if err != nil {
@@ -259,21 +204,17 @@ func manageRemote(r *git.Repository, remote types.Remote) error {
 	return nil
 }
 
-func headSignedBy(r *git.Repository, publicKeys []string) (signedBy *openpgp.Entity, err error) {
-	head, _ := r.Head()
-	if head == nil {
-		return nil, fmt.Errorf("repository HEAD should not be nil")
-	}
-	commit, err := r.CommitObject(head.Hash())
+func commitSignedBy(r *git.Repository, commitId string, publicKeys []string) (signedBy *openpgp.Entity, err error) {
+	commit, err := r.CommitObject(plumbing.NewHash(commitId))
 	if err != nil {
 		return nil, err
 	}
 	for _, k := range publicKeys {
 		entity, err := commit.Verify(k)
 		if err == nil {
-			logrus.Debugf("Commit %s signed by %s", head.Hash(), entity.PrimaryIdentity().Name)
+			logrus.Debugf("Commit %s signed by %s", commitId, entity.PrimaryIdentity().Name)
 			return entity, nil
 		}
 	}
-	return nil, fmt.Errorf("commit %s is not signed", head.Hash())
+	return nil, fmt.Errorf("commit %s is not signed", commitId)
 }

--- a/internal/repository/git_test.go
+++ b/internal/repository/git_test.go
@@ -8,12 +8,8 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-git/v5"
-	gitConfig "github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/filemode"
-	"github.com/go-git/go-git/v5/plumbing/format/index"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/nlewo/comin/internal/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -137,131 +133,21 @@ func TestHeadSignedBy(t *testing.T) {
 
 	r, _ := os.Open("./test.private")
 	entityList, _ := openpgp.ReadArmoredKeyRing(r)
-	_, _ = commitFileAndSign(remoteRepository, dir, "main", "file-1", entityList[0])
+	commitId, _ := commitFileAndSign(remoteRepository, dir, "main", "file-1", entityList[0])
 
 	failPublic, _ := os.ReadFile("./fail.public")
 	testPublic, _ := os.ReadFile("./test.public")
-	signedBy, err := headSignedBy(remoteRepository, []string{string(failPublic), string(testPublic)})
+	signedBy, err := commitSignedBy(remoteRepository, commitId, []string{string(failPublic), string(testPublic)})
 	assert.Nil(t, err)
 	assert.Equal(t, "test <test@comin.space>", signedBy.PrimaryIdentity().Name)
 
-	signedBy, err = headSignedBy(remoteRepository, []string{string(failPublic)})
+	signedBy, err = commitSignedBy(remoteRepository, commitId, []string{string(failPublic)})
 	assert.ErrorContains(t, err, "is not signed")
 	assert.Nil(t, signedBy)
 
-	_, _ = commitFileAndSign(remoteRepository, dir, "main", "file-2", nil)
-	signedBy, err = headSignedBy(remoteRepository, []string{string(failPublic), string(testPublic)})
+	commitId, _ = commitFileAndSign(remoteRepository, dir, "main", "file-2", nil)
+	signedBy, err = commitSignedBy(remoteRepository, commitId, []string{string(failPublic), string(testPublic)})
 	assert.ErrorContains(t, err, "is not signed")
 	assert.Nil(t, signedBy)
 
-}
-
-func TestHardReset(t *testing.T) {
-	tests := []struct {
-		name        string
-		submodules  bool
-		expectExist bool
-	}{
-		{"with submodules enabled", true, true},
-		{"without submodules", false, false},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			submoduleDir := t.TempDir()
-			mainRepoDir := t.TempDir()
-
-			submoduleRepo, err := git.PlainInit(submoduleDir, false)
-			assert.Nil(t, err)
-
-			submoduleCommitId, err := commitFile(submoduleRepo, submoduleDir, "main", "submodule-content")
-			assert.Nil(t, err)
-
-			mainRepo, err := git.PlainInit(mainRepoDir, false)
-			assert.Nil(t, err)
-
-			_, err = commitFile(mainRepo, mainRepoDir, "main", "main-file")
-			assert.Nil(t, err)
-
-			err = addSubmoduleWithCommit(mainRepo, mainRepoDir, "mysub", submoduleDir, submoduleCommitId)
-			assert.Nil(t, err)
-
-			w, err := mainRepo.Worktree()
-			assert.Nil(t, err)
-
-			commitHash, err := w.Commit("add submodule", &git.CommitOptions{
-				Author: &object.Signature{
-					Name:  "John Doe",
-					Email: "john@doe.org",
-					When:  time.Unix(0, 0),
-				},
-			})
-			assert.Nil(t, err)
-
-			r := repository{
-				Repository: mainRepo,
-				GitConfig: types.GitConfig{
-					Submodules: tt.submodules,
-				},
-			}
-
-			err = hardReset(r, commitHash, nil)
-			assert.Nil(t, err)
-
-			submoduleContentPath := filepath.Join(mainRepoDir, "mysub", "submodule-content")
-			_, err = os.Stat(submoduleContentPath)
-			if tt.expectExist {
-				assert.Nil(t, err, "submodule content should exist after hardReset with submodules enabled")
-			} else {
-				assert.True(t, os.IsNotExist(err), "submodule content should NOT exist after hardReset with submodules disabled")
-			}
-		})
-	}
-}
-
-func addSubmoduleWithCommit(repo *git.Repository, repoDir, path, url, commitId string) error {
-	gitmodulesContent := `[submodule "` + path + `"]
-	path = ` + path + `
-	url = ` + url + `
-`
-	err := os.WriteFile(filepath.Join(repoDir, ".gitmodules"), []byte(gitmodulesContent), 0644)
-	if err != nil {
-		return err
-	}
-
-	w, err := repo.Worktree()
-	if err != nil {
-		return err
-	}
-
-	_, err = w.Add(".gitmodules")
-	if err != nil {
-		return err
-	}
-
-	cfg, err := repo.Config()
-	if err != nil {
-		return err
-	}
-	cfg.Submodules[path] = &gitConfig.Submodule{
-		Path: path,
-		URL:  url,
-	}
-	err = repo.SetConfig(cfg)
-	if err != nil {
-		return err
-	}
-
-	idx, err := repo.Storer.Index()
-	if err != nil {
-		return err
-	}
-
-	idx.Entries = append(idx.Entries, &index.Entry{
-		Name: path,
-		Hash: plumbing.NewHash(commitId),
-		Mode: filemode.Submodule,
-	})
-
-	return repo.Storer.SetIndex(idx)
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/nlewo/comin/internal/prometheus"
 	pb "github.com/nlewo/comin/internal/protobuf"
 	"github.com/nlewo/comin/internal/types"
@@ -203,15 +202,9 @@ func (r *repository) Update() error {
 		r.RepositoryStatus.SelectedCommitId = selectedCommitId
 	}
 
-	auth := getAuthForRemote(r.GitConfig, r.RepositoryStatus.SelectedRemoteName)
-	if err := hardReset(*r, plumbing.NewHash(selectedCommitId), auth); err != nil {
-		r.RepositoryStatus.ErrorMsg = err.Error()
-		return err
-	}
-
 	if len(r.gpgPubliKeys) > 0 {
 		r.RepositoryStatus.SelectedCommitShouldBeSigned = wrapperspb.Bool(true)
-		signedBy, err := headSignedBy(r.Repository, r.gpgPubliKeys)
+		signedBy, err := commitSignedBy(r.Repository, selectedCommitId, r.gpgPubliKeys)
 		if err != nil {
 			r.RepositoryStatus.ErrorMsg = err.Error()
 		}

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -260,7 +260,7 @@ func TestMultipleRemote(t *testing.T) {
 	// r2/main: c1 - c2 - c3
 	r.Fetch([]string{"r1", "r2"})
 	_ = r.Update()
-	assert.Equal(t, HeadCommitId(r.Repository), r.RepositoryStatus.SelectedCommitId)
+	assert.Equal(t, HeadCommitId(r1), r.RepositoryStatus.SelectedCommitId)
 	assert.Equal(t, "main", r.RepositoryStatus.SelectedBranchName)
 	assert.Equal(t, "r1", r.RepositoryStatus.SelectedRemoteName)
 
@@ -443,7 +443,7 @@ func TestWithoutTesting(t *testing.T) {
 	var err error
 	r1Dir := t.TempDir()
 	cominRepositoryDir := t.TempDir()
-	_, err = initRemoteRepostiory(r1Dir, false)
+	r1, err := initRemoteRepostiory(r1Dir, false)
 	assert.Nil(t, err)
 	gitConfig := types.GitConfig{
 		Path: cominRepositoryDir,
@@ -467,7 +467,7 @@ func TestWithoutTesting(t *testing.T) {
 
 	r.Fetch([]string{"r1"})
 	_ = r.Update()
-	assert.Equal(t, HeadCommitId(r.Repository), r.RepositoryStatus.SelectedCommitId)
+	assert.Equal(t, HeadCommitId(r1), r.RepositoryStatus.SelectedCommitId)
 	assert.Equal(t, "main", r.RepositoryStatus.SelectedBranchName)
 	assert.Equal(t, "r1", r.RepositoryStatus.SelectedRemoteName)
 }
@@ -501,14 +501,14 @@ func TestRepositoryUpdateMain(t *testing.T) {
 	// The remote repository is initially checkouted
 	r.Fetch([]string{"origin"})
 	_ = r.Update()
-	assert.Equal(t, HeadCommitId(r.Repository), r.RepositoryStatus.SelectedCommitId)
+	assert.Equal(t, HeadCommitId(remoteRepository), r.RepositoryStatus.SelectedCommitId)
 	assert.Equal(t, "main", r.RepositoryStatus.SelectedBranchName)
 	assert.Equal(t, "origin", r.RepositoryStatus.SelectedRemoteName)
 
 	// Without any new remote commits, the local repository is not updated
 	r.Fetch([]string{"origin"})
 	_ = r.Update()
-	assert.Equal(t, HeadCommitId(r.Repository), r.RepositoryStatus.SelectedCommitId)
+	assert.Equal(t, HeadCommitId(remoteRepository), r.RepositoryStatus.SelectedCommitId)
 	assert.Equal(t, "main", r.RepositoryStatus.SelectedBranchName)
 	assert.Equal(t, "origin", r.RepositoryStatus.SelectedRemoteName)
 
@@ -560,7 +560,7 @@ func TestRepositoryUpdateHardResetMain(t *testing.T) {
 	// The remote repository is initially checkouted
 	r.Fetch([]string{"origin"})
 	_ = r.Update()
-	assert.Equal(t, HeadCommitId(r.Repository), r.RepositoryStatus.SelectedCommitId)
+	assert.Equal(t, HeadCommitId(remoteRepository), r.RepositoryStatus.SelectedCommitId)
 	assert.Equal(t, "main", r.RepositoryStatus.SelectedBranchName)
 	assert.Equal(t, "origin", r.RepositoryStatus.SelectedRemoteName)
 
@@ -619,7 +619,7 @@ func TestRepositoryUpdateTesting(t *testing.T) {
 	// The remote repository is initially checkouted on main
 	r.Fetch([]string{"origin"})
 	_ = r.Update()
-	assert.Equal(t, HeadCommitId(r.Repository), r.RepositoryStatus.SelectedCommitId)
+	assert.Equal(t, HeadCommitId(remoteRepository), r.RepositoryStatus.SelectedCommitId)
 	assert.Equal(t, "main", r.RepositoryStatus.SelectedBranchName)
 	assert.Equal(t, "origin", r.RepositoryStatus.SelectedRemoteName)
 


### PR DESCRIPTION
Initially, comin was evaluating Nix expression from the local repository. But, since few releases, it clone this repository to solve race issues.

We then no longer need to checkout this repository, neither hard reset it.