### PR TITLE
Support switch inhibitors

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -6,11 +6,12 @@ import (
 	"os"
 	"strings"
 
+	"time"
+
 	lipgloss "charm.land/lipgloss/v2"
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"time"
 
 	"github.com/dustin/go-humanize"
 	"github.com/nlewo/comin/internal/client"
@@ -243,7 +244,8 @@ func (dm DeployerModel) View() string {
 				b.WriteString("  " + labelStyle.Render("Message:   ") + msg + "\n")
 			}
 		}
-		b.WriteString("  " + labelStyle.Render("Operation: ") + d.Operation + "\n")
+		operation := d.Operation
+		b.WriteString("  " + labelStyle.Render("Operation: ") + operation + "\n")
 
 		switch d.Status {
 		case store.StatusToString(store.Running):

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -117,7 +117,7 @@ func (c Client) Resume() error {
 	return err
 }
 func (c Client) DeploymentLatestSubmit(operation string) error {
-	_, err := c.cominClient.DeploymentLatestSubmit(context.Background(), &protobuf.Operation{Operation: operation})
+	_, err := c.cominClient.DeploymentLatestSubmit(context.Background(), &protobuf.Operation{OperationSubmitted: operation})
 	return err
 }
 

--- a/internal/deployer/deployer.go
+++ b/internal/deployer/deployer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dustin/go-humanize"
 	"github.com/nlewo/comin/internal/protobuf"
 	"github.com/nlewo/comin/internal/store"
+	"github.com/nlewo/comin/internal/types"
 	"github.com/nlewo/comin/internal/utils"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -203,6 +204,9 @@ func (d *Deployer) Submit(generation *protobuf.Generation, operation string, for
 func (d *Deployer) Run(ctx context.Context) {
 	go func() {
 		for {
+			var cominNeedRestart bool
+			var profilePath string
+			var err error
 			<-d.generationAvailableCh
 
 			if d.isSuspended.Load() {
@@ -213,12 +217,13 @@ func (d *Deployer) Run(ctx context.Context) {
 
 			d.mu.Lock()
 			g := d.GenerationToDeploy
-			operation := d.Operation
+			operationSubmitted := d.Operation
 			d.GenerationToDeploy = nil
 			d.mu.Unlock()
-			logrus.Infof("deployer: deploying generation %s with operation %s", g.Uuid, operation)
+			logrus.Infof("deployer: deploying generation %s with the submitted operation %s", g.Uuid, operationSubmitted)
 			booted, current := utils.GetBootedAndCurrentStorepaths()
-			dpl := d.store.NewDeployment(g, d.Operation, d.Reason, booted, current)
+			dpl := d.store.NewDeployment(g, operationSubmitted, d.Reason, booted, current)
+			operationComputed := dpl.Operation
 			d.mu.Lock()
 			d.previousDeployment.Swap(d.Deployment())
 			d.deployment.Store(dpl)
@@ -228,14 +233,15 @@ func (d *Deployer) Run(ctx context.Context) {
 				logrus.Errorf("deployer: could not update the deployment %s in the store", dpl.Uuid)
 				continue
 			}
-			profilePaths := d.store.GetDeploymentProfilePaths()
-			cominNeedRestart, profilePath, err := d.deployerFunc(
-				ctx,
-				g.OutPath,
-				operation,
-				profilePaths,
-			)
-
+			if operationComputed != types.OperationNull {
+				profilePaths := d.store.GetDeploymentProfilePaths()
+				cominNeedRestart, profilePath, err = d.deployerFunc(
+					ctx,
+					g.OutPath,
+					operationComputed,
+					profilePaths,
+				)
+			}
 			deployment := d.Deployment()
 			deployment.EndedAt = timestamppb.New(time.Now().UTC())
 			if err := d.store.DeploymentFinished(dpl.Uuid, err, cominNeedRestart, profilePath, booted, current); err != nil {

--- a/internal/deployer/deployer_test.go
+++ b/internal/deployer/deployer_test.go
@@ -1,4 +1,4 @@
-package deployer_test
+package deployer
 
 import (
 	"context"
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/nlewo/comin/internal/broker"
-	"github.com/nlewo/comin/internal/deployer"
 	"github.com/nlewo/comin/internal/protobuf"
 	"github.com/nlewo/comin/internal/store"
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,7 @@ func TestDeployerBasic(t *testing.T) {
 
 	s, err := store.New(bk, tmp+"/state.json", tmp+"/gcroots", 1, 1, 1)
 	assert.Nil(t, err)
-	d := deployer.New(s, deployFunc, nil, "")
+	d := New(s, deployFunc, nil, "")
 	d.Run(t.Context())
 	assert.False(t, d.IsDeploying())
 
@@ -61,7 +60,7 @@ func TestDeployerSubmit(t *testing.T) {
 
 	s, err := store.New(bk, tmp+"/state.json", tmp+"/gcroots", 1, 1, 1)
 	assert.Nil(t, err)
-	d := deployer.New(s, deployFunc, nil, "")
+	d := New(s, deployFunc, nil, "")
 	d.Run(t.Context())
 	assert.False(t, d.IsDeploying())
 
@@ -104,7 +103,7 @@ func TestDeployerSuspend(t *testing.T) {
 
 	s, err := store.New(bk, tmp+"/state.json", tmp+"/gcroots", 1, 1, 1)
 	assert.Nil(t, err)
-	d := deployer.New(s, deployFunc, nil, "")
+	d := New(s, deployFunc, nil, "")
 	d.Run(t.Context())
 	assert.False(t, d.IsSuspended())
 	d.Suspend("suspended for testing")

--- a/internal/protobuf/services.pb.go
+++ b/internal/protobuf/services.pb.go
@@ -28,10 +28,10 @@ const (
 )
 
 type Operation struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Operation     string                 `protobuf:"bytes,1,opt,name=operation" json:"operation,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	OperationSubmitted string                 `protobuf:"bytes,1,opt,name=operation_submitted,json=operationSubmitted" json:"operation_submitted,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Operation) Reset() {
@@ -64,9 +64,9 @@ func (*Operation) Descriptor() ([]byte, []int) {
 	return file_internal_protobuf_services_proto_rawDescGZIP(), []int{0}
 }
 
-func (x *Operation) GetOperation() string {
+func (x *Operation) GetOperationSubmitted() string {
 	if x != nil {
-		return x.Operation
+		return x.OperationSubmitted
 	}
 	return ""
 }
@@ -644,20 +644,24 @@ func (x *Generation) GetBuildErr() string {
 }
 
 type Deployment struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Uuid          string                 `protobuf:"bytes,1,opt,name=uuid" json:"uuid,omitempty"`
-	Reason        string                 `protobuf:"bytes,10,opt,name=reason" json:"reason,omitempty"`
-	Generation    *Generation            `protobuf:"bytes,2,opt,name=generation" json:"generation,omitempty"`
-	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt" json:"started_at,omitempty"`
-	EndedAt       *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=ended_at,json=endedAt" json:"ended_at,omitempty"`
-	ErrorMsg      string                 `protobuf:"bytes,5,opt,name=error_msg,json=errorMsg" json:"error_msg,omitempty"`
-	RestartComin  *wrapperspb.BoolValue  `protobuf:"bytes,6,opt,name=restart_comin,json=restartComin" json:"restart_comin,omitempty"`
-	ProfilePath   string                 `protobuf:"bytes,7,opt,name=profile_path,json=profilePath" json:"profile_path,omitempty"`
-	Status        string                 `protobuf:"bytes,8,opt,name=status" json:"status,omitempty"`
-	Operation     string                 `protobuf:"bytes,9,opt,name=operation" json:"operation,omitempty"`
-	CreatedAt     *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=created_at,json=createdAt" json:"created_at,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state              protoimpl.MessageState `protogen:"open.v1"`
+	Uuid               string                 `protobuf:"bytes,1,opt,name=uuid" json:"uuid,omitempty"`
+	Reason             string                 `protobuf:"bytes,10,opt,name=reason" json:"reason,omitempty"`
+	Generation         *Generation            `protobuf:"bytes,2,opt,name=generation" json:"generation,omitempty"`
+	StartedAt          *timestamppb.Timestamp `protobuf:"bytes,3,opt,name=started_at,json=startedAt" json:"started_at,omitempty"`
+	EndedAt            *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=ended_at,json=endedAt" json:"ended_at,omitempty"`
+	ErrorMsg           string                 `protobuf:"bytes,5,opt,name=error_msg,json=errorMsg" json:"error_msg,omitempty"`
+	RestartComin       *wrapperspb.BoolValue  `protobuf:"bytes,6,opt,name=restart_comin,json=restartComin" json:"restart_comin,omitempty"`
+	ProfilePath        string                 `protobuf:"bytes,7,opt,name=profile_path,json=profilePath" json:"profile_path,omitempty"`
+	Status             string                 `protobuf:"bytes,8,opt,name=status" json:"status,omitempty"`
+	OperationSubmitted string                 `protobuf:"bytes,12,opt,name=operation_submitted,json=operationSubmitted" json:"operation_submitted,omitempty"`
+	Operation          string                 `protobuf:"bytes,9,opt,name=operation" json:"operation,omitempty"`
+	OperationReason    string                 `protobuf:"bytes,15,opt,name=operation_reason,json=operationReason" json:"operation_reason,omitempty"`
+	CreatedAt          *timestamppb.Timestamp `protobuf:"bytes,11,opt,name=created_at,json=createdAt" json:"created_at,omitempty"`
+	CurrentInhibitors  map[string]string      `protobuf:"bytes,13,rep,name=current_inhibitors,json=currentInhibitors" json:"current_inhibitors,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	NewInhibitors      map[string]string      `protobuf:"bytes,14,rep,name=new_inhibitors,json=newInhibitors" json:"new_inhibitors,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *Deployment) Reset() {
@@ -753,6 +757,13 @@ func (x *Deployment) GetStatus() string {
 	return ""
 }
 
+func (x *Deployment) GetOperationSubmitted() string {
+	if x != nil {
+		return x.OperationSubmitted
+	}
+	return ""
+}
+
 func (x *Deployment) GetOperation() string {
 	if x != nil {
 		return x.Operation
@@ -760,9 +771,30 @@ func (x *Deployment) GetOperation() string {
 	return ""
 }
 
+func (x *Deployment) GetOperationReason() string {
+	if x != nil {
+		return x.OperationReason
+	}
+	return ""
+}
+
 func (x *Deployment) GetCreatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.CreatedAt
+	}
+	return nil
+}
+
+func (x *Deployment) GetCurrentInhibitors() map[string]string {
+	if x != nil {
+		return x.CurrentInhibitors
+	}
+	return nil
+}
+
+func (x *Deployment) GetNewInhibitors() map[string]string {
+	if x != nil {
+		return x.NewInhibitors
 	}
 	return nil
 }
@@ -2253,9 +2285,9 @@ var File_internal_protobuf_services_proto protoreflect.FileDescriptor
 
 const file_internal_protobuf_services_proto_rawDesc = "" +
 	"\n" +
-	" internal/protobuf/services.proto\x12\bprotobuf\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\")\n" +
-	"\tOperation\x12\x1c\n" +
-	"\toperation\x18\x01 \x01(\tR\toperation\"\xa0\x0f\n" +
+	" internal/protobuf/services.proto\x12\bprotobuf\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x1egoogle/protobuf/wrappers.proto\"<\n" +
+	"\tOperation\x12/\n" +
+	"\x13operation_submitted\x18\x01 \x01(\tR\x12operationSubmitted\"\xa0\x0f\n" +
 	"\x05Event\x12G\n" +
 	"\x0fevalStartedType\x18\x01 \x01(\v2\x1b.protobuf.Event.EvalStartedH\x00R\x0fevalStartedType\x12J\n" +
 	"\x10evalFinishedType\x18\x02 \x01(\v2\x1c.protobuf.Event.EvalFinishedH\x00R\x10evalFinishedType\x12J\n" +
@@ -2349,7 +2381,7 @@ const file_internal_protobuf_services_proto_rawDesc = "" +
 	"\fbuild_reason\x18\x1b \x01(\tR\vbuildReason\x12D\n" +
 	"\x10build_started_at\x18\x15 \x01(\v2\x1a.google.protobuf.TimestampR\x0ebuildStartedAt\x12@\n" +
 	"\x0ebuild_ended_at\x18\x16 \x01(\v2\x1a.google.protobuf.TimestampR\fbuildEndedAt\x12\x1b\n" +
-	"\tbuild_err\x18\x17 \x01(\tR\bbuildErr\"\xd2\x03\n" +
+	"\tbuild_err\x18\x17 \x01(\tR\bbuildErr\"\xe2\x06\n" +
 	"\n" +
 	"Deployment\x12\x12\n" +
 	"\x04uuid\x18\x01 \x01(\tR\x04uuid\x12\x16\n" +
@@ -2364,10 +2396,20 @@ const file_internal_protobuf_services_proto_rawDesc = "" +
 	"\terror_msg\x18\x05 \x01(\tR\berrorMsg\x12?\n" +
 	"\rrestart_comin\x18\x06 \x01(\v2\x1a.google.protobuf.BoolValueR\frestartComin\x12!\n" +
 	"\fprofile_path\x18\a \x01(\tR\vprofilePath\x12\x16\n" +
-	"\x06status\x18\b \x01(\tR\x06status\x12\x1c\n" +
-	"\toperation\x18\t \x01(\tR\toperation\x129\n" +
+	"\x06status\x18\b \x01(\tR\x06status\x12/\n" +
+	"\x13operation_submitted\x18\f \x01(\tR\x12operationSubmitted\x12\x1c\n" +
+	"\toperation\x18\t \x01(\tR\toperation\x12)\n" +
+	"\x10operation_reason\x18\x0f \x01(\tR\x0foperationReason\x129\n" +
 	"\n" +
-	"created_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\"\xb7\x03\n" +
+	"created_at\x18\v \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12Z\n" +
+	"\x12current_inhibitors\x18\r \x03(\v2+.protobuf.Deployment.CurrentInhibitorsEntryR\x11currentInhibitors\x12N\n" +
+	"\x0enew_inhibitors\x18\x0e \x03(\v2'.protobuf.Deployment.NewInhibitorsEntryR\rnewInhibitors\x1aD\n" +
+	"\x16CurrentInhibitorsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1a@\n" +
+	"\x12NewInhibitorsEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xb7\x03\n" +
 	"\x05State\x12@\n" +
 	"\x0eneed_to_reboot\x18\x01 \x01(\v2\x1a.google.protobuf.BoolValueR\fneedToReboot\x12=\n" +
 	"\fis_suspended\x18\x02 \x01(\v2\x1a.google.protobuf.BoolValueR\visSuspended\x12+\n" +
@@ -2471,7 +2513,7 @@ func file_internal_protobuf_services_proto_rawDescGZIP() []byte {
 	return file_internal_protobuf_services_proto_rawDescData
 }
 
-var file_internal_protobuf_services_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_internal_protobuf_services_proto_msgTypes = make([]protoimpl.MessageInfo, 31)
 var file_internal_protobuf_services_proto_goTypes = []any{
 	(*Operation)(nil),                   // 0: protobuf.Operation
 	(*Event)(nil),                       // 1: protobuf.Event
@@ -2502,9 +2544,11 @@ var file_internal_protobuf_services_proto_goTypes = []any{
 	(*Event_RebootRequired)(nil),        // 26: protobuf.Event.RebootRequired
 	(*Event_ManagerState)(nil),          // 27: protobuf.Event.ManagerState
 	(*Event_Fetched)(nil),               // 28: protobuf.Event.Fetched
-	(*wrapperspb.BoolValue)(nil),        // 29: google.protobuf.BoolValue
-	(*timestamppb.Timestamp)(nil),       // 30: google.protobuf.Timestamp
-	(*emptypb.Empty)(nil),               // 31: google.protobuf.Empty
+	nil,                                 // 29: protobuf.Deployment.CurrentInhibitorsEntry
+	nil,                                 // 30: protobuf.Deployment.NewInhibitorsEntry
+	(*wrapperspb.BoolValue)(nil),        // 31: google.protobuf.BoolValue
+	(*timestamppb.Timestamp)(nil),       // 32: google.protobuf.Timestamp
+	(*emptypb.Empty)(nil),               // 33: google.protobuf.Empty
 }
 var file_internal_protobuf_services_proto_depIdxs = []int32{
 	15, // 0: protobuf.Event.evalStartedType:type_name -> protobuf.Event.EvalStarted
@@ -2521,76 +2565,78 @@ var file_internal_protobuf_services_proto_depIdxs = []int32{
 	26, // 11: protobuf.Event.rebootRequired:type_name -> protobuf.Event.RebootRequired
 	27, // 12: protobuf.Event.managerState:type_name -> protobuf.Event.ManagerState
 	28, // 13: protobuf.Event.fetched:type_name -> protobuf.Event.Fetched
-	29, // 14: protobuf.Generation.selected_branch_is_testing:type_name -> google.protobuf.BoolValue
-	30, // 15: protobuf.Generation.eval_started_at:type_name -> google.protobuf.Timestamp
-	30, // 16: protobuf.Generation.eval_ended_at:type_name -> google.protobuf.Timestamp
-	30, // 17: protobuf.Generation.build_started_at:type_name -> google.protobuf.Timestamp
-	30, // 18: protobuf.Generation.build_ended_at:type_name -> google.protobuf.Timestamp
+	31, // 14: protobuf.Generation.selected_branch_is_testing:type_name -> google.protobuf.BoolValue
+	32, // 15: protobuf.Generation.eval_started_at:type_name -> google.protobuf.Timestamp
+	32, // 16: protobuf.Generation.eval_ended_at:type_name -> google.protobuf.Timestamp
+	32, // 17: protobuf.Generation.build_started_at:type_name -> google.protobuf.Timestamp
+	32, // 18: protobuf.Generation.build_ended_at:type_name -> google.protobuf.Timestamp
 	3,  // 19: protobuf.Deployment.generation:type_name -> protobuf.Generation
-	30, // 20: protobuf.Deployment.started_at:type_name -> google.protobuf.Timestamp
-	30, // 21: protobuf.Deployment.ended_at:type_name -> google.protobuf.Timestamp
-	29, // 22: protobuf.Deployment.restart_comin:type_name -> google.protobuf.BoolValue
-	30, // 23: protobuf.Deployment.created_at:type_name -> google.protobuf.Timestamp
-	29, // 24: protobuf.State.need_to_reboot:type_name -> google.protobuf.BoolValue
-	29, // 25: protobuf.State.is_suspended:type_name -> google.protobuf.BoolValue
-	7,  // 26: protobuf.State.builder:type_name -> protobuf.Builder
-	6,  // 27: protobuf.State.deployer:type_name -> protobuf.Deployer
-	9,  // 28: protobuf.State.fetcher:type_name -> protobuf.Fetcher
-	14, // 29: protobuf.State.store:type_name -> protobuf.Store
-	8,  // 30: protobuf.State.build_confirmer:type_name -> protobuf.Confirmer
-	8,  // 31: protobuf.State.deploy_confirmer:type_name -> protobuf.Confirmer
-	29, // 32: protobuf.Deployer.is_deploying:type_name -> google.protobuf.BoolValue
-	4,  // 33: protobuf.Deployer.deployment:type_name -> protobuf.Deployment
-	3,  // 34: protobuf.Deployer.generation_to_deploy:type_name -> protobuf.Generation
-	4,  // 35: protobuf.Deployer.previous_deployment:type_name -> protobuf.Deployment
-	29, // 36: protobuf.Deployer.is_suspended:type_name -> google.protobuf.BoolValue
-	29, // 37: protobuf.Builder.is_evaluating:type_name -> google.protobuf.BoolValue
-	29, // 38: protobuf.Builder.is_building:type_name -> google.protobuf.BoolValue
-	3,  // 39: protobuf.Builder.generation:type_name -> protobuf.Generation
-	29, // 40: protobuf.Builder.is_suspended:type_name -> google.protobuf.BoolValue
-	30, // 41: protobuf.Confirmer.autoconfirm_started_at:type_name -> google.protobuf.Timestamp
-	29, // 42: protobuf.Confirmer.autoconfirm_started:type_name -> google.protobuf.BoolValue
-	29, // 43: protobuf.Fetcher.is_fetching:type_name -> google.protobuf.BoolValue
-	12, // 44: protobuf.Fetcher.repository_status:type_name -> protobuf.RepositoryStatus
-	10, // 45: protobuf.Remote.main:type_name -> protobuf.Branch
-	10, // 46: protobuf.Remote.testing:type_name -> protobuf.Branch
-	30, // 47: protobuf.Remote.fetched_at:type_name -> google.protobuf.Timestamp
-	29, // 48: protobuf.Remote.fetched:type_name -> google.protobuf.BoolValue
-	29, // 49: protobuf.RepositoryStatus.selected_branch_is_testing:type_name -> google.protobuf.BoolValue
-	29, // 50: protobuf.RepositoryStatus.selected_commit_signed:type_name -> google.protobuf.BoolValue
-	29, // 51: protobuf.RepositoryStatus.selected_commit_should_be_signed:type_name -> google.protobuf.BoolValue
-	11, // 52: protobuf.RepositoryStatus.remotes:type_name -> protobuf.Remote
-	4,  // 53: protobuf.Store.deployments:type_name -> protobuf.Deployment
-	3,  // 54: protobuf.Store.generations:type_name -> protobuf.Generation
-	13, // 55: protobuf.Store.deployer:type_name -> protobuf.DeployerState
-	3,  // 56: protobuf.Event.EvalStarted.generation:type_name -> protobuf.Generation
-	3,  // 57: protobuf.Event.EvalFinished.generation:type_name -> protobuf.Generation
-	3,  // 58: protobuf.Event.BuildStarted.generation:type_name -> protobuf.Generation
-	3,  // 59: protobuf.Event.BuildFinished.generation:type_name -> protobuf.Generation
-	4,  // 60: protobuf.Event.DeploymentStarted.deployment:type_name -> protobuf.Deployment
-	4,  // 61: protobuf.Event.DeploymentFinished.deployment:type_name -> protobuf.Deployment
-	4,  // 62: protobuf.Event.RebootRequired.deployment:type_name -> protobuf.Deployment
-	5,  // 63: protobuf.Event.ManagerState.state:type_name -> protobuf.State
-	12, // 64: protobuf.Event.Fetched.repositoryStatus:type_name -> protobuf.RepositoryStatus
-	31, // 65: protobuf.Comin.GetState:input_type -> google.protobuf.Empty
-	31, // 66: protobuf.Comin.Fetch:input_type -> google.protobuf.Empty
-	31, // 67: protobuf.Comin.Suspend:input_type -> google.protobuf.Empty
-	31, // 68: protobuf.Comin.Resume:input_type -> google.protobuf.Empty
-	2,  // 69: protobuf.Comin.Confirm:input_type -> protobuf.ConfirmRequest
-	31, // 70: protobuf.Comin.Events:input_type -> google.protobuf.Empty
-	0,  // 71: protobuf.Comin.DeploymentLatestSubmit:input_type -> protobuf.Operation
-	5,  // 72: protobuf.Comin.GetState:output_type -> protobuf.State
-	31, // 73: protobuf.Comin.Fetch:output_type -> google.protobuf.Empty
-	31, // 74: protobuf.Comin.Suspend:output_type -> google.protobuf.Empty
-	31, // 75: protobuf.Comin.Resume:output_type -> google.protobuf.Empty
-	31, // 76: protobuf.Comin.Confirm:output_type -> google.protobuf.Empty
-	1,  // 77: protobuf.Comin.Events:output_type -> protobuf.Event
-	31, // 78: protobuf.Comin.DeploymentLatestSubmit:output_type -> google.protobuf.Empty
-	72, // [72:79] is the sub-list for method output_type
-	65, // [65:72] is the sub-list for method input_type
-	65, // [65:65] is the sub-list for extension type_name
-	65, // [65:65] is the sub-list for extension extendee
-	0,  // [0:65] is the sub-list for field type_name
+	32, // 20: protobuf.Deployment.started_at:type_name -> google.protobuf.Timestamp
+	32, // 21: protobuf.Deployment.ended_at:type_name -> google.protobuf.Timestamp
+	31, // 22: protobuf.Deployment.restart_comin:type_name -> google.protobuf.BoolValue
+	32, // 23: protobuf.Deployment.created_at:type_name -> google.protobuf.Timestamp
+	29, // 24: protobuf.Deployment.current_inhibitors:type_name -> protobuf.Deployment.CurrentInhibitorsEntry
+	30, // 25: protobuf.Deployment.new_inhibitors:type_name -> protobuf.Deployment.NewInhibitorsEntry
+	31, // 26: protobuf.State.need_to_reboot:type_name -> google.protobuf.BoolValue
+	31, // 27: protobuf.State.is_suspended:type_name -> google.protobuf.BoolValue
+	7,  // 28: protobuf.State.builder:type_name -> protobuf.Builder
+	6,  // 29: protobuf.State.deployer:type_name -> protobuf.Deployer
+	9,  // 30: protobuf.State.fetcher:type_name -> protobuf.Fetcher
+	14, // 31: protobuf.State.store:type_name -> protobuf.Store
+	8,  // 32: protobuf.State.build_confirmer:type_name -> protobuf.Confirmer
+	8,  // 33: protobuf.State.deploy_confirmer:type_name -> protobuf.Confirmer
+	31, // 34: protobuf.Deployer.is_deploying:type_name -> google.protobuf.BoolValue
+	4,  // 35: protobuf.Deployer.deployment:type_name -> protobuf.Deployment
+	3,  // 36: protobuf.Deployer.generation_to_deploy:type_name -> protobuf.Generation
+	4,  // 37: protobuf.Deployer.previous_deployment:type_name -> protobuf.Deployment
+	31, // 38: protobuf.Deployer.is_suspended:type_name -> google.protobuf.BoolValue
+	31, // 39: protobuf.Builder.is_evaluating:type_name -> google.protobuf.BoolValue
+	31, // 40: protobuf.Builder.is_building:type_name -> google.protobuf.BoolValue
+	3,  // 41: protobuf.Builder.generation:type_name -> protobuf.Generation
+	31, // 42: protobuf.Builder.is_suspended:type_name -> google.protobuf.BoolValue
+	32, // 43: protobuf.Confirmer.autoconfirm_started_at:type_name -> google.protobuf.Timestamp
+	31, // 44: protobuf.Confirmer.autoconfirm_started:type_name -> google.protobuf.BoolValue
+	31, // 45: protobuf.Fetcher.is_fetching:type_name -> google.protobuf.BoolValue
+	12, // 46: protobuf.Fetcher.repository_status:type_name -> protobuf.RepositoryStatus
+	10, // 47: protobuf.Remote.main:type_name -> protobuf.Branch
+	10, // 48: protobuf.Remote.testing:type_name -> protobuf.Branch
+	32, // 49: protobuf.Remote.fetched_at:type_name -> google.protobuf.Timestamp
+	31, // 50: protobuf.Remote.fetched:type_name -> google.protobuf.BoolValue
+	31, // 51: protobuf.RepositoryStatus.selected_branch_is_testing:type_name -> google.protobuf.BoolValue
+	31, // 52: protobuf.RepositoryStatus.selected_commit_signed:type_name -> google.protobuf.BoolValue
+	31, // 53: protobuf.RepositoryStatus.selected_commit_should_be_signed:type_name -> google.protobuf.BoolValue
+	11, // 54: protobuf.RepositoryStatus.remotes:type_name -> protobuf.Remote
+	4,  // 55: protobuf.Store.deployments:type_name -> protobuf.Deployment
+	3,  // 56: protobuf.Store.generations:type_name -> protobuf.Generation
+	13, // 57: protobuf.Store.deployer:type_name -> protobuf.DeployerState
+	3,  // 58: protobuf.Event.EvalStarted.generation:type_name -> protobuf.Generation
+	3,  // 59: protobuf.Event.EvalFinished.generation:type_name -> protobuf.Generation
+	3,  // 60: protobuf.Event.BuildStarted.generation:type_name -> protobuf.Generation
+	3,  // 61: protobuf.Event.BuildFinished.generation:type_name -> protobuf.Generation
+	4,  // 62: protobuf.Event.DeploymentStarted.deployment:type_name -> protobuf.Deployment
+	4,  // 63: protobuf.Event.DeploymentFinished.deployment:type_name -> protobuf.Deployment
+	4,  // 64: protobuf.Event.RebootRequired.deployment:type_name -> protobuf.Deployment
+	5,  // 65: protobuf.Event.ManagerState.state:type_name -> protobuf.State
+	12, // 66: protobuf.Event.Fetched.repositoryStatus:type_name -> protobuf.RepositoryStatus
+	33, // 67: protobuf.Comin.GetState:input_type -> google.protobuf.Empty
+	33, // 68: protobuf.Comin.Fetch:input_type -> google.protobuf.Empty
+	33, // 69: protobuf.Comin.Suspend:input_type -> google.protobuf.Empty
+	33, // 70: protobuf.Comin.Resume:input_type -> google.protobuf.Empty
+	2,  // 71: protobuf.Comin.Confirm:input_type -> protobuf.ConfirmRequest
+	33, // 72: protobuf.Comin.Events:input_type -> google.protobuf.Empty
+	0,  // 73: protobuf.Comin.DeploymentLatestSubmit:input_type -> protobuf.Operation
+	5,  // 74: protobuf.Comin.GetState:output_type -> protobuf.State
+	33, // 75: protobuf.Comin.Fetch:output_type -> google.protobuf.Empty
+	33, // 76: protobuf.Comin.Suspend:output_type -> google.protobuf.Empty
+	33, // 77: protobuf.Comin.Resume:output_type -> google.protobuf.Empty
+	33, // 78: protobuf.Comin.Confirm:output_type -> google.protobuf.Empty
+	1,  // 79: protobuf.Comin.Events:output_type -> protobuf.Event
+	33, // 80: protobuf.Comin.DeploymentLatestSubmit:output_type -> google.protobuf.Empty
+	74, // [74:81] is the sub-list for method output_type
+	67, // [67:74] is the sub-list for method input_type
+	67, // [67:67] is the sub-list for extension type_name
+	67, // [67:67] is the sub-list for extension extendee
+	0,  // [0:67] is the sub-list for field type_name
 }
 
 func init() { file_internal_protobuf_services_proto_init() }
@@ -2620,7 +2666,7 @@ func file_internal_protobuf_services_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_internal_protobuf_services_proto_rawDesc), len(file_internal_protobuf_services_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   29,
+			NumMessages:   31,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/internal/protobuf/services.proto
+++ b/internal/protobuf/services.proto
@@ -23,7 +23,7 @@ service Comin {
 }
 
 message Operation {
-  string operation = 1;
+  string operation_submitted = 1;
 }
 
 message Event {
@@ -141,8 +141,12 @@ message Deployment {
   google.protobuf.BoolValue restart_comin = 6;
   string profile_path = 7;
   string status = 8;
+  string operation_submitted = 12;
   string operation = 9;
+  string operation_reason = 15;
   google.protobuf.Timestamp created_at = 11;
+  map<string, string> current_inhibitors = 13;
+  map<string, string> new_inhibitors = 14;
 }
 
 message State {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -62,7 +62,7 @@ func (s *cominServer) Fetch(ctx context.Context, empty *emptypb.Empty) (*emptypb
 }
 
 func (s *cominServer) DeploymentLatestSubmit(ctx context.Context, operation *protobuf.Operation) (*emptypb.Empty, error) {
-	err := s.manager.DeploymentLatestSubmit(operation.Operation)
+	err := s.manager.DeploymentLatestSubmit(operation.OperationSubmitted)
 	if err != nil {
 		st := status.New(codes.Aborted, err.Error())
 		err = st.Err()

--- a/internal/store/deployment.go
+++ b/internal/store/deployment.go
@@ -1,13 +1,17 @@
 package store
 
 import (
+	"encoding/json"
 	"fmt"
 	"maps"
+	"os"
+	"path"
 	"slices"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/nlewo/comin/internal/protobuf"
+	"github.com/nlewo/comin/internal/types"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -113,16 +117,40 @@ func (s *Store) updateDataDeployments(bootedStorepath, currentStorepath string, 
 	s.Commit()
 }
 
-func (s *Store) NewDeployment(g *protobuf.Generation, operation, reason, bootedStorepath, currentStorepath string) *protobuf.Deployment {
+func loadInhibitors(filepath string) map[string]string {
+	if _, err := os.Stat(filepath); err != nil {
+		return nil
+	}
+	file, err := os.Open(filepath)
+	if err != nil {
+		return nil
+	}
+	defer file.Close() // nolint: errcheck
+	var inhibitors map[string]string
+	if err := json.NewDecoder(file).Decode(&inhibitors); err != nil {
+		return nil
+	}
+	return inhibitors
+}
+
+func (s *Store) NewDeployment(g *protobuf.Generation, operationSubmitted, reason, bootedStorepath, currentStorepath string) *protobuf.Deployment {
+	currentInhibitors := loadInhibitors(path.Join(currentStorepath, "switch-inhibitors"))
+	newInhibitors := loadInhibitors(path.Join(g.OutPath, "switch-inhibitors"))
+	operation, operationreason := computeOperation(operationSubmitted, currentInhibitors, newInhibitors)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	d := &protobuf.Deployment{
-		Uuid:       uuid.New().String(),
-		Generation: g,
-		Operation:  operation,
-		Reason:     reason,
-		Status:     StatusToString(Init),
-		CreatedAt:  timestamppb.New(time.Now().UTC()),
+		Uuid:               uuid.New().String(),
+		Generation:         g,
+		OperationSubmitted: operationSubmitted,
+		Operation:          operation,
+		OperationReason:    operationreason,
+		Reason:             reason,
+		Status:             StatusToString(Init),
+		CreatedAt:          timestamppb.New(time.Now().UTC()),
+		CurrentInhibitors:  currentInhibitors,
+		NewInhibitors:      newInhibitors,
 	}
 	s.updateDataDeployments(bootedStorepath, currentStorepath, d)
 	s.Commit()
@@ -282,4 +310,47 @@ func retention(dpls []*protobuf.Deployment, new *protobuf.Deployment, bootedStor
 	}
 
 	return current, booted, deploymentsBootEntry, deploymentsSuccessful, deploymentsAny
+}
+
+type inhibitorChange struct {
+	old string
+	new string
+}
+
+// compareSwitchInhibitors is a Go implementation of https://github.com/nixos/nixpkgs/blob/ddce4d809a16b9f0614e76636063282f6fb02908/nixos/modules/system/activation/switchable-system.nix#L101
+func compareSwitchInhibitors(current map[string]string, new map[string]string) (diff map[string]inhibitorChange) {
+	diff = make(map[string]inhibitorChange)
+	for k, v := range current {
+		if _, ok := new[k]; ok {
+			diff[k] = inhibitorChange{old: v}
+		}
+
+	}
+	for k, v := range new {
+		if existing, ok := diff[k]; ok {
+			if existing.old != v {
+				existing.new = v
+				diff[k] = existing
+			} else {
+				delete(diff, k)
+			}
+		}
+	}
+
+	return
+}
+
+func computeOperation(operation string, currentInhibitors map[string]string, newInhibitors map[string]string) (computedOperation string, reason string) {
+	diff := compareSwitchInhibitors(currentInhibitors, newInhibitors)
+	switch operation {
+	case types.OperationTest:
+		if len(diff) != 0 {
+			return types.OperationNull, "The test operation is not possible because of different switch inhibitors"
+		}
+	case types.OperationSwitch:
+		if len(diff) != 0 {
+			return types.OperationBoot, "Using the boot operation instead of switch operation because of diffrent switch inhibitors"
+		}
+	}
+	return operation, ""
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -170,3 +170,31 @@ func TestNewGeneration(t *testing.T) {
 	s, _ := New(bk, tmp+"/filename", tmp+"/gcroots", 2, 2, 5)
 	s.NewGeneration("hostname", "repositoryPath", "repositoryDir", "systemAttr", &protobuf.RepositoryStatus{})
 }
+
+func TestCompareSwitchInhibitors(t *testing.T) {
+	oldInhibitors := map[string]string{
+		"inhibitor1": "old-value-1",
+		"inhibitor2": "old-value-2",
+		"common":     "common",
+	}
+	newInhibitors := map[string]string{
+		"inhibitor2": "new-value-2",
+		"inhibitor3": "new-value-3",
+		"common":     "common",
+	}
+
+	diff := compareSwitchInhibitors(oldInhibitors, newInhibitors)
+	assert.Len(t, diff, 1)
+	assert.Equal(t, inhibitorChange{old: "old-value-2", new: "new-value-2"}, diff["inhibitor2"])
+
+	diff = compareSwitchInhibitors(map[string]string{}, newInhibitors)
+	assert.Len(t, diff, 0)
+
+	// Test with empty new map
+	diff = compareSwitchInhibitors(oldInhibitors, map[string]string{})
+	assert.Len(t, diff, 0)
+
+	// Test with both maps empty
+	diff = compareSwitchInhibitors(map[string]string{}, map[string]string{})
+	assert.Len(t, diff, 0)
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,5 +1,10 @@
 package types
 
+const OperationTest = "test"
+const OperationSwitch = "switch"
+const OperationBoot = "boot"
+const OperationNull = "null"
+
 type Remote struct {
 	Name     string
 	URL      string


### PR DESCRIPTION
NixOS introduced the switch inhibitors feature which is used to detect that a switch would break the system, meaning a reboot would be required instead.

When comin detects such situations, it changes the switch operation to a boot operation.

This is reported by the comin status: Deployment.Operation indicates the desired operation while Deployment.OperationComputed indicates the operation conputed based on switch inhibotors.

Note the switch inhibitor implementation is available at https://github.com/nixos/nixpkgs/blob/ddce4d809a16b9f0614e76636063282f6fb02908/nixos/modules/system/activation/switchable-system.nix#L101.

Fixes https://github.com/nlewo/comin/issues/155

TODO:
- [x] test it on real systems