### PR TITLE
Metrics: use broker to collect metrics and expose failed status

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -141,6 +141,9 @@ var runCmd = &cobra.Command{
 			cfg.Exporter.ListenAddress, cfg.Exporter.Port)
 		srv := server.New(broker, manager, cfg.Grpc.UnixSocketPath)
 		srv.Start()
+
+		prometheus.Subscribe(broker, &metrics)
+
 		manager.Run(cmd.Context())
 	},
 }

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -136,7 +136,6 @@ func (m *Manager) Suspend() error {
 	}
 	m.deployer.Suspend("manager has been manually suspended")
 	m.isSuspended = true
-	m.prometheus.SetIsSuspended(m.isSuspended)
 	m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_Suspend_{Suspend: &protobuf.Event_Suspend{}}, CreatedAt: timestamppb.New(time.Now().UTC())})
 	return nil
 }
@@ -150,7 +149,6 @@ func (m *Manager) Resume(ctx context.Context) error {
 	}
 	m.deployer.Resume()
 	m.isSuspended = false
-	m.prometheus.SetIsSuspended(m.isSuspended)
 	m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_Resume_{Resume: &protobuf.Event_Resume{}}, CreatedAt: timestamppb.New(time.Now().UTC())})
 	return nil
 }
@@ -242,8 +240,6 @@ func (m *Manager) Run(ctx context.Context) {
 	if lastDpl != nil {
 		m.needToReboot = m.executor.NeedToReboot(lastDpl.Generation.OutPath, lastDpl.Operation)
 	}
-	m.prometheus.SetNeedToReboot(m.needToReboot)
-	m.prometheus.SetIsSuspended(m.isSuspended)
 
 	m.FetchAndBuild(ctx)
 	m.deployer.Run(ctx)
@@ -253,13 +249,11 @@ func (m *Manager) Run(ctx context.Context) {
 		case <-m.stateRequestCh:
 			m.stateResultCh <- m.toState()
 		case dpl := <-m.deployer.DeploymentDoneCh:
-			m.prometheus.SetDeploymentInfo(dpl.Generation.SelectedCommitId, dpl.Status)
 			m.needToReboot = m.executor.NeedToReboot(dpl.Generation.OutPath, dpl.Operation)
 			if m.needToReboot {
 				e := &protobuf.Event_RebootRequired{Deployment: dpl}
 				m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_RebootRequired_{RebootRequired: e}, CreatedAt: timestamppb.New(time.Now().UTC())})
 			}
-			m.prometheus.SetNeedToReboot(m.needToReboot)
 			if dpl.RestartComin.GetValue() {
 				// TODO: stop contexts
 				logrus.Infof("manager: comin needs to be restarted")

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -17,11 +17,11 @@ import (
 	"github.com/nlewo/comin/internal/executor"
 	"github.com/nlewo/comin/internal/fetcher"
 	"github.com/nlewo/comin/internal/prometheus"
-	"github.com/nlewo/comin/pkg/protobuf"
 	"github.com/nlewo/comin/internal/scheduler"
-	"google.golang.org/protobuf/types/known/timestamppb"
 	"github.com/nlewo/comin/internal/store"
+	"github.com/nlewo/comin/pkg/protobuf"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -73,7 +73,7 @@ func New(s *store.Store,
 
 	m := &Manager{
 		machineId: machineId,
-		Hostname:   hostname,
+		Hostname:  hostname,
 
 		stateRequestCh:          make(chan struct{}),
 		stateResultCh:           make(chan *protobuf.State),
@@ -136,7 +136,6 @@ func (m *Manager) Suspend() error {
 	}
 	m.deployer.Suspend("manager has been manually suspended")
 	m.isSuspended = true
-	m.prometheus.SetHostInfo(m.needToReboot, m.isSuspended)
 	m.prometheus.SetIsSuspended(m.isSuspended)
 	m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_Suspend_{Suspend: &protobuf.Event_Suspend{}}, CreatedAt: timestamppb.New(time.Now().UTC())})
 	return nil
@@ -151,7 +150,6 @@ func (m *Manager) Resume(ctx context.Context) error {
 	}
 	m.deployer.Resume()
 	m.isSuspended = false
-	m.prometheus.SetHostInfo(m.needToReboot, m.isSuspended)
 	m.prometheus.SetIsSuspended(m.isSuspended)
 	m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_Resume_{Resume: &protobuf.Event_Resume{}}, CreatedAt: timestamppb.New(time.Now().UTC())})
 	return nil
@@ -244,7 +242,6 @@ func (m *Manager) Run(ctx context.Context) {
 	if lastDpl != nil {
 		m.needToReboot = m.executor.NeedToReboot(lastDpl.Generation.OutPath, lastDpl.Operation)
 	}
-	m.prometheus.SetHostInfo(m.needToReboot, m.isSuspended)
 	m.prometheus.SetNeedToReboot(m.needToReboot)
 	m.prometheus.SetIsSuspended(m.isSuspended)
 
@@ -262,7 +259,6 @@ func (m *Manager) Run(ctx context.Context) {
 				e := &protobuf.Event_RebootRequired{Deployment: dpl}
 				m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_RebootRequired_{RebootRequired: e}, CreatedAt: timestamppb.New(time.Now().UTC())})
 			}
-			m.prometheus.SetHostInfo(m.needToReboot, m.isSuspended)
 			m.prometheus.SetNeedToReboot(m.needToReboot)
 			if dpl.RestartComin.GetValue() {
 				// TODO: stop contexts

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -104,9 +104,14 @@ func Subscribe(broker *brokerPkg.Broker, metrics *Prometheus) {
 					buildFinished.GetGeneration().GetBuildStatus() == "failed"),
 				)
 			}
-			if deploymentFinished := m.GetDeploymentFinishedType(); deploymentFinished != nil {
+			if lastDeployment := m.GetDeploymentFinishedType(); lastDeployment != nil {
 				metrics.lastDeploymentFailed.Set(boolToFloat64(
-					deploymentFinished.GetDeployment().GetStatus() == "failed"),
+					lastDeployment.GetDeployment().GetStatus() == "failed"),
+				)
+
+				metrics.SetDeploymentInfo(
+					lastDeployment.GetDeployment().GetGeneration().GetMainCommitId(),
+					lastDeployment.GetDeployment().GetStatus(),
 				)
 			}
 			if m.GetSuspend() != nil {

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -46,19 +46,19 @@ func New() Prometheus {
 	})
 
 	lastFetchFailed := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_fetch_failed",
+		Name: "comin_last_fetch_failed",
 		Help: "Whether the last fetch (all of the repositories) failed (1) or not (0).",
 	})
 	lastEvalFailed := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_eval_failed",
+		Name: "comin_last_eval_failed",
 		Help: "Whether the last evaluation failed (1) or not (0).",
 	})
 	lastBuildFailed := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_build_failed",
+		Name: "comin_last_build_failed",
 		Help: "Whether the last build failed (1) or not (0).",
 	})
 	lastDeploymentFailed := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_deployment_failed",
+		Name: "comin_last_deployment_failed",
 		Help: "Whether the last deployment failed (1) or not (0).",
 	})
 	promReg.MustRegister(buildInfo)

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -132,9 +132,9 @@ func (m Prometheus) SetlastFetchFailed(lastFetchFailed bool) {
 func (m Prometheus) SetLastEvalFailed(lastEvalFailed bool) {
 	m.lastEvalFailed.Set(boolToFloat64(lastEvalFailed))
 }
-func (m Prometheus) SetlastBuildFailed(lastBuildFailed bool) {
+func (m Prometheus) SetLastBuildFailed(lastBuildFailed bool) {
 	m.lastBuildFailed.Set(boolToFloat64(lastBuildFailed))
 }
-func (m Prometheus) SetlastDeploymentFailed(lastDeploymentFailed bool) {
+func (m Prometheus) SetLastDeploymentFailed(lastDeploymentFailed bool) {
 	m.lastDeploymentFailed.Set(boolToFloat64(lastDeploymentFailed))
 }

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -132,7 +132,7 @@ func updateFetched(fetched *protobuf.Event_Fetched, metrics *Prometheus) {
 		}
 
 		metrics.IncFetchCounter(repo.GetName(), status)
-		metrics.lastFetchFailed.With(prometheus.Labels{"remote_name": remoteName}).Set(boolToFloat64(!success))
+		metrics.lastFetchFailed.With(prometheus.Labels{"remote_name": repo.GetName()}).Set(boolToFloat64(!success))
 	}
 }
 

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -162,13 +162,6 @@ func (m Prometheus) SetLastFetchFailed(remoteName string, failed bool) {
 	m.lastFetchFailed.With(prometheus.Labels{"remote_name": remoteName}).Set(boolToFloat64(failed))
 }
 
-func boolToString(b bool) string {
-	if b {
-		return "1"
-	}
-	return "0"
-}
-
 func boolToFloat64(b bool) float64 {
 	if b {
 		return 1

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -123,6 +123,7 @@ func Subscribe(broker *brokerPkg.Broker, metrics *Prometheus) {
 }
 
 func updateFetched(fetched *protobuf.Event_Fetched, metrics *Prometheus) {
+	metrics.lastFetchFailed.Reset()
 	for _, repo := range fetched.RepositoryStatus.GetRemotes() {
 		status := "failed"
 		success := repo.GetFetched().GetValue()
@@ -131,7 +132,7 @@ func updateFetched(fetched *protobuf.Event_Fetched, metrics *Prometheus) {
 		}
 
 		metrics.IncFetchCounter(repo.GetName(), status)
-		metrics.SetLastFetchFailed(repo.GetName(), !success)
+		metrics.lastFetchFailed.With(prometheus.Labels{"remote_name": remoteName}).Set(boolToFloat64(!success))
 	}
 }
 
@@ -155,11 +156,6 @@ func (m Prometheus) SetBuildInfo(version string) {
 func (m Prometheus) SetDeploymentInfo(commitId, status string) {
 	m.deploymentInfo.Reset()
 	m.deploymentInfo.With(prometheus.Labels{"commit_id": commitId, "status": status}).Set(1)
-}
-
-func (m Prometheus) SetLastFetchFailed(remoteName string, failed bool) {
-	m.lastFetchFailed.Reset()
-	m.lastFetchFailed.With(prometheus.Labels{"remote_name": remoteName}).Set(boolToFloat64(failed))
 }
 
 func boolToFloat64(b bool) float64 {

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -15,6 +15,7 @@ type Prometheus struct {
 	isSuspended          prometheus.Gauge
 	needToReboot         prometheus.Gauge
 	lastFetchFailed      prometheus.Gauge
+	lastEvalFailed       prometheus.Gauge
 	lastBuildFailed      prometheus.Gauge
 	lastDeploymentFailed prometheus.Gauge
 }
@@ -46,6 +47,10 @@ func New() Prometheus {
 		Name: "last_fetch_failed",
 		Help: "Whether the last fetch (all of the repositories) failed (1) or not (0).",
 	})
+	lastEvalFailed := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_eval_failed",
+		Help: "Whether the last evaluation failed (1) or not (0).",
+	})
 	lastBuildFailed := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "last_build_failed",
 		Help: "Whether the last build failed (1) or not (0).",
@@ -60,6 +65,7 @@ func New() Prometheus {
 	promReg.MustRegister(isSuspended)
 	promReg.MustRegister(needToReboot)
 	promReg.MustRegister(lastFetchFailed)
+	promReg.MustRegister(lastEvalFailed)
 	promReg.MustRegister(lastBuildFailed)
 	promReg.MustRegister(lastDeploymentFailed)
 	return Prometheus{
@@ -70,6 +76,7 @@ func New() Prometheus {
 		isSuspended:          isSuspended,
 		needToReboot:         needToReboot,
 		lastFetchFailed:      lastFetchFailed,
+		lastEvalFailed:       lastEvalFailed,
 		lastBuildFailed:      lastBuildFailed,
 		lastDeploymentFailed: lastDeploymentFailed,
 	}
@@ -121,6 +128,9 @@ func (m Prometheus) SetNeedToReboot(needToReboot bool) {
 
 func (m Prometheus) SetlastFetchFailed(lastFetchFailed bool) {
 	m.lastFetchFailed.Set(boolToFloat64(lastFetchFailed))
+}
+func (m Prometheus) SetLastEvalFailed(lastEvalFailed bool) {
+	m.lastEvalFailed.Set(boolToFloat64(lastEvalFailed))
 }
 func (m Prometheus) SetlastBuildFailed(lastBuildFailed bool) {
 	m.lastBuildFailed.Set(boolToFloat64(lastBuildFailed))

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -95,28 +95,28 @@ func Subscribe(broker *brokerPkg.Broker, metrics *Prometheus) {
 				updateFetched(fetched, metrics)
 			}
 			if evalFinished := m.GetEvalFinishedType(); evalFinished != nil {
-				metrics.SetLastEvalFailed(
+				metrics.lastEvalFailed.Set(boolToFloat64(
 					evalFinished.GetGeneration().GetEvalStatus() == "failed",
-				)
+				))
 			}
 			if buildFinished := m.GetBuildFinishedType(); buildFinished != nil {
-				metrics.SetLastBuildFailed(
-					buildFinished.GetGeneration().GetBuildStatus() == "failed",
+				metrics.lastBuildFailed.Set(boolToFloat64(
+					buildFinished.GetGeneration().GetBuildStatus() == "failed"),
 				)
 			}
 			if deploymentFinished := m.GetDeploymentFinishedType(); deploymentFinished != nil {
-				metrics.SetLastDeploymentFailed(
-					deploymentFinished.GetDeployment().GetStatus() == "failed",
+				metrics.lastDeploymentFailed.Set(boolToFloat64(
+					deploymentFinished.GetDeployment().GetStatus() == "failed"),
 				)
 			}
 			if m.GetSuspend() != nil {
-				metrics.SetIsSuspended(true)
+				metrics.isSuspended.Set(boolToFloat64(true))
 			}
 			if m.GetResume() != nil {
-				metrics.SetIsSuspended(false)
+				metrics.isSuspended.Set(boolToFloat64(false))
 			}
 			if m.GetRebootRequired() != nil {
-				metrics.SetNeedToReboot(true)
+				metrics.needToReboot.Set(boolToFloat64(true))
 			}
 		}
 	})()
@@ -134,7 +134,7 @@ func updateFetched(fetched *protobuf.Event_Fetched, metrics *Prometheus) {
 
 		metrics.IncFetchCounter(repo.GetName(), status)
 	}
-	metrics.SetlastFetchFailed(allFailed)
+	metrics.lastFetchFailed.Set(boolToFloat64(allFailed))
 }
 
 func (m Prometheus) Handler() http.Handler {
@@ -171,25 +171,4 @@ func boolToFloat64(b bool) float64 {
 		return 1
 	}
 	return 0
-}
-
-func (m Prometheus) SetIsSuspended(isSuspended bool) {
-	m.isSuspended.Set(boolToFloat64(isSuspended))
-}
-
-func (m Prometheus) SetNeedToReboot(needToReboot bool) {
-	m.needToReboot.Set(boolToFloat64(needToReboot))
-}
-
-func (m Prometheus) SetlastFetchFailed(lastFetchFailed bool) {
-	m.lastFetchFailed.Set(boolToFloat64(lastFetchFailed))
-}
-func (m Prometheus) SetLastEvalFailed(lastEvalFailed bool) {
-	m.lastEvalFailed.Set(boolToFloat64(lastEvalFailed))
-}
-func (m Prometheus) SetLastBuildFailed(lastBuildFailed bool) {
-	m.lastBuildFailed.Set(boolToFloat64(lastBuildFailed))
-}
-func (m Prometheus) SetLastDeploymentFailed(lastDeploymentFailed bool) {
-	m.lastDeploymentFailed.Set(boolToFloat64(lastDeploymentFailed))
 }

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -90,37 +90,32 @@ func Subscribe(broker *brokerPkg.Broker, metrics *Prometheus) {
 
 		for {
 			m := <-c
+			switch {
+			case m.GetFetched() != nil:
+				updateFetched(m.GetFetched(), metrics)
 
-			if fetched := m.GetFetched(); fetched != nil {
-				updateFetched(fetched, metrics)
-			}
-			if evalFinished := m.GetEvalFinishedType(); evalFinished != nil {
+			case m.GetEvalFinishedType() != nil:
 				metrics.lastEvalFailed.Set(boolToFloat64(
-					evalFinished.GetGeneration().GetEvalStatus() == "failed",
+					m.GetEvalFinishedType().GetGeneration().GetEvalStatus() == "failed",
 				))
-			}
-			if buildFinished := m.GetBuildFinishedType(); buildFinished != nil {
-				metrics.lastBuildFailed.Set(boolToFloat64(
-					buildFinished.GetGeneration().GetBuildStatus() == "failed"),
-				)
-			}
-			if lastDeployment := m.GetDeploymentFinishedType(); lastDeployment != nil {
-				metrics.lastDeploymentFailed.Set(boolToFloat64(
-					lastDeployment.GetDeployment().GetStatus() == "failed"),
-				)
 
-				metrics.SetDeploymentInfo(
-					lastDeployment.GetDeployment().GetGeneration().GetMainCommitId(),
-					lastDeployment.GetDeployment().GetStatus(),
-				)
-			}
-			if m.GetSuspend() != nil {
+			case m.GetBuildFinishedType() != nil:
+				metrics.lastBuildFailed.Set(boolToFloat64(
+					m.GetBuildFinishedType().GetGeneration().GetBuildStatus() == "failed",
+				))
+
+			case m.GetDeploymentFinishedType() != nil:
+				d := m.GetDeploymentFinishedType().GetDeployment()
+				metrics.lastDeploymentFailed.Set(boolToFloat64(d.GetStatus() == "failed"))
+				metrics.SetDeploymentInfo(d.GetGeneration().GetMainCommitId(), d.GetStatus())
+
+			case m.GetSuspend() != nil:
 				metrics.isSuspended.Set(boolToFloat64(true))
-			}
-			if m.GetResume() != nil {
+
+			case m.GetResume() != nil:
 				metrics.isSuspended.Set(boolToFloat64(false))
-			}
-			if m.GetRebootRequired() != nil {
+
+			case m.GetRebootRequired() != nil:
 				metrics.needToReboot.Set(boolToFloat64(true))
 			}
 		}

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -8,15 +8,15 @@ import (
 )
 
 type Prometheus struct {
-	promRegistry             *prometheus.Registry
-	buildInfo                *prometheus.GaugeVec
-	deploymentInfo           *prometheus.GaugeVec
-	fetchCounter             *prometheus.CounterVec
-	isSuspended              prometheus.Gauge
-	needToReboot             prometheus.Gauge
-	lastFetchSuccessful      prometheus.Gauge
-	lastBuildSuccessful      prometheus.Gauge
-	lastDeploymentSuccessful prometheus.Gauge
+	promRegistry         *prometheus.Registry
+	buildInfo            *prometheus.GaugeVec
+	deploymentInfo       *prometheus.GaugeVec
+	fetchCounter         *prometheus.CounterVec
+	isSuspended          prometheus.Gauge
+	needToReboot         prometheus.Gauge
+	lastFetchFailed      prometheus.Gauge
+	lastBuildFailed      prometheus.Gauge
+	lastDeploymentFailed prometheus.Gauge
 }
 
 func New() Prometheus {
@@ -42,36 +42,36 @@ func New() Prometheus {
 		Help: "Whether the host needs to reboot (1) or not (0).",
 	})
 
-	lastFetchSuccessful := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_fetch_successful",
-		Help: "Whether the last fetch (any of the repositories) was successful (1) or not (0).",
+	lastFetchFailed := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_fetch_failed",
+		Help: "Whether the last fetch (all of the repositories) failed (1) or not (0).",
 	})
-	lastBuildSuccessful := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_build_successful",
-		Help: "Whether the last build was successful (1) or not (0).",
+	lastBuildFailed := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_build_failed",
+		Help: "Whether the last build failed (1) or not (0).",
 	})
-	lastDeploymentSuccessful := prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "last_deployment_successful",
-		Help: "Whether the last deployment was successful (1) or not (0).",
+	lastDeploymentFailed := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_deployment_failed",
+		Help: "Whether the last deployment failed (1) or not (0).",
 	})
 	promReg.MustRegister(buildInfo)
 	promReg.MustRegister(deploymentInfo)
 	promReg.MustRegister(fetchCounter)
 	promReg.MustRegister(isSuspended)
 	promReg.MustRegister(needToReboot)
-	promReg.MustRegister(lastFetchSuccessful)
-	promReg.MustRegister(lastBuildSuccessful)
-	promReg.MustRegister(lastDeploymentSuccessful)
+	promReg.MustRegister(lastFetchFailed)
+	promReg.MustRegister(lastBuildFailed)
+	promReg.MustRegister(lastDeploymentFailed)
 	return Prometheus{
-		promRegistry:             promReg,
-		buildInfo:                buildInfo,
-		deploymentInfo:           deploymentInfo,
-		fetchCounter:             fetchCounter,
-		isSuspended:              isSuspended,
-		needToReboot:             needToReboot,
-		lastFetchSuccessful:      lastFetchSuccessful,
-		lastBuildSuccessful:      lastBuildSuccessful,
-		lastDeploymentSuccessful: lastDeploymentSuccessful,
+		promRegistry:         promReg,
+		buildInfo:            buildInfo,
+		deploymentInfo:       deploymentInfo,
+		fetchCounter:         fetchCounter,
+		isSuspended:          isSuspended,
+		needToReboot:         needToReboot,
+		lastFetchFailed:      lastFetchFailed,
+		lastBuildFailed:      lastBuildFailed,
+		lastDeploymentFailed: lastDeploymentFailed,
 	}
 }
 
@@ -119,12 +119,12 @@ func (m Prometheus) SetNeedToReboot(needToReboot bool) {
 	m.needToReboot.Set(boolToFloat64(needToReboot))
 }
 
-func (m Prometheus) SetLastFetchSuccessful(lastFetchSuccessful bool) {
-	m.lastFetchSuccessful.Set(boolToFloat64(lastFetchSuccessful))
+func (m Prometheus) SetlastFetchFailed(lastFetchFailed bool) {
+	m.lastFetchFailed.Set(boolToFloat64(lastFetchFailed))
 }
-func (m Prometheus) SetLastBuildSuccessful(lastBuildSuccessful bool) {
-	m.lastBuildSuccessful.Set(boolToFloat64(lastBuildSuccessful))
+func (m Prometheus) SetlastBuildFailed(lastBuildFailed bool) {
+	m.lastBuildFailed.Set(boolToFloat64(lastBuildFailed))
 }
-func (m Prometheus) SetLastDeploymentSuccessful(lastDeploymentSuccessful bool) {
-	m.lastDeploymentSuccessful.Set(boolToFloat64(lastDeploymentSuccessful))
+func (m Prometheus) SetlastDeploymentFailed(lastDeploymentFailed bool) {
+	m.lastDeploymentFailed.Set(boolToFloat64(lastDeploymentFailed))
 }

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -3,6 +3,8 @@ package prometheus
 import (
 	"net/http"
 
+	brokerPkg "github.com/nlewo/comin/internal/broker"
+	"github.com/nlewo/comin/pkg/protobuf"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
@@ -80,6 +82,59 @@ func New() Prometheus {
 		lastBuildFailed:      lastBuildFailed,
 		lastDeploymentFailed: lastDeploymentFailed,
 	}
+}
+
+func Subscribe(broker *brokerPkg.Broker, metrics *Prometheus) {
+	go (func() {
+		c := broker.Subscribe()
+
+		for {
+			m := <-c
+
+			if fetched := m.GetFetched(); fetched != nil {
+				updateFetched(fetched, metrics)
+			}
+			if evalFinished := m.GetEvalFinishedType(); evalFinished != nil {
+				metrics.SetLastEvalFailed(
+					evalFinished.GetGeneration().GetEvalStatus() == "failed",
+				)
+			}
+			if buildFinished := m.GetBuildFinishedType(); buildFinished != nil {
+				metrics.SetLastBuildFailed(
+					buildFinished.GetGeneration().GetBuildStatus() == "failed",
+				)
+			}
+			if deploymentFinished := m.GetDeploymentFinishedType(); deploymentFinished != nil {
+				metrics.SetLastDeploymentFailed(
+					deploymentFinished.GetDeployment().GetStatus() == "failed",
+				)
+			}
+			if m.GetSuspend() != nil {
+				metrics.SetIsSuspended(true)
+			}
+			if m.GetResume() != nil {
+				metrics.SetIsSuspended(false)
+			}
+			if m.GetRebootRequired() != nil {
+				metrics.SetNeedToReboot(true)
+			}
+		}
+	})()
+}
+
+func updateFetched(fetched *protobuf.Event_Fetched, metrics *Prometheus) {
+	allFailed := true
+	for _, repo := range fetched.RepositoryStatus.GetRemotes() {
+		status := "failed"
+		success := repo.GetFetched().GetValue()
+		if success {
+			status = "succeeded"
+			allFailed = false
+		}
+
+		metrics.IncFetchCounter(repo.GetName(), status)
+	}
+	metrics.SetlastFetchFailed(allFailed)
 }
 
 func (m Prometheus) Handler() http.Handler {

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -8,14 +8,15 @@ import (
 )
 
 type Prometheus struct {
-	promRegistry   *prometheus.Registry
-	buildInfo      *prometheus.GaugeVec
-	deploymentInfo *prometheus.GaugeVec
-	fetchCounter   *prometheus.CounterVec
-	// TODO: deprecated: remove for the next release
-	hostInfo     *prometheus.GaugeVec
-	isSuspended  prometheus.Gauge
-	needToReboot prometheus.Gauge
+	promRegistry             *prometheus.Registry
+	buildInfo                *prometheus.GaugeVec
+	deploymentInfo           *prometheus.GaugeVec
+	fetchCounter             *prometheus.CounterVec
+	isSuspended              prometheus.Gauge
+	needToReboot             prometheus.Gauge
+	lastFetchSuccessful      prometheus.Gauge
+	lastBuildSuccessful      prometheus.Gauge
+	lastDeploymentSuccessful prometheus.Gauge
 }
 
 func New() Prometheus {
@@ -32,11 +33,6 @@ func New() Prometheus {
 		Name: "comin_fetch_count",
 		Help: "Number of fetches per status",
 	}, []string{"remote_name", "status"})
-	// TODO: deprecated: remove for the next release
-	hostInfo := prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "comin_host_info",
-		Help: "(DEPRECATED) Info of the host.",
-	}, []string{"is_suspended", "need_to_reboot"})
 	isSuspended := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "comin_is_suspended",
 		Help: "Whether the host is suspended (1) or not (0).",
@@ -45,22 +41,37 @@ func New() Prometheus {
 		Name: "comin_need_to_reboot",
 		Help: "Whether the host needs to reboot (1) or not (0).",
 	})
+
+	lastFetchSuccessful := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_fetch_successful",
+		Help: "Whether the last fetch (any of the repositories) was successful (1) or not (0).",
+	})
+	lastBuildSuccessful := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_build_successful",
+		Help: "Whether the last build was successful (1) or not (0).",
+	})
+	lastDeploymentSuccessful := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "last_deployment_successful",
+		Help: "Whether the last deployment was successful (1) or not (0).",
+	})
 	promReg.MustRegister(buildInfo)
 	promReg.MustRegister(deploymentInfo)
 	promReg.MustRegister(fetchCounter)
-	// TODO: deprecated: remove for the next release
-	promReg.MustRegister(hostInfo)
 	promReg.MustRegister(isSuspended)
 	promReg.MustRegister(needToReboot)
+	promReg.MustRegister(lastFetchSuccessful)
+	promReg.MustRegister(lastBuildSuccessful)
+	promReg.MustRegister(lastDeploymentSuccessful)
 	return Prometheus{
-		promRegistry:   promReg,
-		buildInfo:      buildInfo,
-		deploymentInfo: deploymentInfo,
-		fetchCounter:   fetchCounter,
-		// TODO: deprecated: remove for the next release
-		hostInfo:     hostInfo,
-		isSuspended:  isSuspended,
-		needToReboot: needToReboot,
+		promRegistry:             promReg,
+		buildInfo:                buildInfo,
+		deploymentInfo:           deploymentInfo,
+		fetchCounter:             fetchCounter,
+		isSuspended:              isSuspended,
+		needToReboot:             needToReboot,
+		lastFetchSuccessful:      lastFetchSuccessful,
+		lastBuildSuccessful:      lastBuildSuccessful,
+		lastDeploymentSuccessful: lastDeploymentSuccessful,
 	}
 }
 
@@ -100,19 +111,20 @@ func boolToFloat64(b bool) float64 {
 	return 0
 }
 
-// TODO: deprecated: remove for the next release
-func (m Prometheus) SetHostInfo(needToReboot bool, isSuspended bool) {
-	m.hostInfo.Reset()
-	m.hostInfo.With(prometheus.Labels{
-		"need_to_reboot": boolToString(needToReboot),
-		"is_suspended":   boolToString(isSuspended),
-	}).Set(1)
-}
-
 func (m Prometheus) SetIsSuspended(isSuspended bool) {
 	m.isSuspended.Set(boolToFloat64(isSuspended))
 }
 
 func (m Prometheus) SetNeedToReboot(needToReboot bool) {
 	m.needToReboot.Set(boolToFloat64(needToReboot))
+}
+
+func (m Prometheus) SetLastFetchSuccessful(lastFetchSuccessful bool) {
+	m.lastFetchSuccessful.Set(boolToFloat64(lastFetchSuccessful))
+}
+func (m Prometheus) SetLastBuildSuccessful(lastBuildSuccessful bool) {
+	m.lastBuildSuccessful.Set(boolToFloat64(lastBuildSuccessful))
+}
+func (m Prometheus) SetLastDeploymentSuccessful(lastDeploymentSuccessful bool) {
+	m.lastDeploymentSuccessful.Set(boolToFloat64(lastDeploymentSuccessful))
 }

--- a/internal/prometheus/prometheus.go
+++ b/internal/prometheus/prometheus.go
@@ -16,7 +16,7 @@ type Prometheus struct {
 	fetchCounter         *prometheus.CounterVec
 	isSuspended          prometheus.Gauge
 	needToReboot         prometheus.Gauge
-	lastFetchFailed      prometheus.Gauge
+	lastFetchFailed      *prometheus.GaugeVec
 	lastEvalFailed       prometheus.Gauge
 	lastBuildFailed      prometheus.Gauge
 	lastDeploymentFailed prometheus.Gauge
@@ -45,10 +45,10 @@ func New() Prometheus {
 		Help: "Whether the host needs to reboot (1) or not (0).",
 	})
 
-	lastFetchFailed := prometheus.NewGauge(prometheus.GaugeOpts{
+	lastFetchFailed := prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "comin_last_fetch_failed",
 		Help: "Whether the last fetch (all of the repositories) failed (1) or not (0).",
-	})
+	}, []string{"remote_name"})
 	lastEvalFailed := prometheus.NewGauge(prometheus.GaugeOpts{
 		Name: "comin_last_eval_failed",
 		Help: "Whether the last evaluation failed (1) or not (0).",
@@ -128,18 +128,16 @@ func Subscribe(broker *brokerPkg.Broker, metrics *Prometheus) {
 }
 
 func updateFetched(fetched *protobuf.Event_Fetched, metrics *Prometheus) {
-	allFailed := true
 	for _, repo := range fetched.RepositoryStatus.GetRemotes() {
 		status := "failed"
 		success := repo.GetFetched().GetValue()
 		if success {
 			status = "succeeded"
-			allFailed = false
 		}
 
 		metrics.IncFetchCounter(repo.GetName(), status)
+		metrics.SetLastFetchFailed(repo.GetName(), !success)
 	}
-	metrics.lastFetchFailed.Set(boolToFloat64(allFailed))
 }
 
 func (m Prometheus) Handler() http.Handler {
@@ -162,6 +160,11 @@ func (m Prometheus) SetBuildInfo(version string) {
 func (m Prometheus) SetDeploymentInfo(commitId, status string) {
 	m.deploymentInfo.Reset()
 	m.deploymentInfo.With(prometheus.Labels{"commit_id": commitId, "status": status}).Set(1)
+}
+
+func (m Prometheus) SetLastFetchFailed(remoteName string, failed bool) {
+	m.lastFetchFailed.Reset()
+	m.lastFetchFailed.With(prometheus.Labels{"remote_name": remoteName}).Set(boolToFloat64(failed))
 }
 
 func boolToString(b bool) string {


### PR DESCRIPTION
This PR removes metrics from the manager and creates a broker subscriber that listens to incoming messages on the channel and exposes metrics from them. Furthermore, it exposes 4 new metrics: `last_fetch_failed`, `last_eval_failed`, `last_build_failed`, and `last_deployment_failed` which allows for alerting when any of those stages fail.

This was coded late at night so it may contain some dumb mistakes

Design decisions:
- I opted for failed states instead of successful states since upon starting Comin, for most people there will be no successful eval/build/deployment until there has been an explicit fetch and push, this would trigger alerts if alerting is set to alert on e.g. "no successful builds for 10 minutes". The failed states allow for alerts like "failed build for the last 10 minutes"
- I reused the internal/prometheus/prometheus.go for the broker subscribe since it already colocates all metrics things
- Subscribe uses a `go (func())()` which I find kinda ugly but is used across the codebase (e.g. in server/server.go)

