### PR TITLE
Implement ssh key auth

### DIFF
--- a/docs/generated-module-options.md
+++ b/docs/generated-module-options.md
@@ -500,6 +500,51 @@ string
 
 
 
+## services\.comin\.remotes\.\*\.auth\.ssh_deploy_key_path
+
+
+
+Path to the SSH private key used to authenticate to the Git remote\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
+## services\.comin\.remotes\.\*\.auth\.ssh_known_hosts_path
+
+
+
+Path to the known_hosts file used to verify the SSH
+host key of the Git remote\. Defaults to
+/etc/ssh/ssh_known_hosts when unset\. The remote’s host
+key must be present in this file\.
+
+
+
+*Type:*
+null or absolute path
+
+
+
+*Default:*
+
+```nix
+null
+```
+
+
+
 ## services\.comin\.remotes\.\*\.auth\.username
 
 

--- a/internal/repository/git.go
+++ b/internal/repository/git.go
@@ -3,8 +3,8 @@ package repository
 import (
 	"context"
 	"fmt"
-	"time"
 	"os"
+	"time"
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-git/v5"
@@ -15,34 +15,6 @@ import (
 	"github.com/nlewo/comin/internal/types"
 	"github.com/sirupsen/logrus"
 )
-
-func RepositoryClone(directory, url, commitId, accessToken string) error {
-	options := &git.CloneOptions{
-		URL:        url,
-		NoCheckout: true,
-	}
-	if accessToken != "" {
-		options.Auth = &http.BasicAuth{
-			Username: "comin",
-			Password: accessToken,
-		}
-	}
-	repository, err := git.PlainClone(directory, false, options)
-	if err != nil {
-		return err
-	}
-	worktree, err := repository.Worktree()
-	if err != nil {
-		return err
-	}
-	err = worktree.Checkout(&git.CheckoutOptions{
-		Hash: plumbing.NewHash(commitId),
-	})
-	if err != nil {
-		return fmt.Errorf("cannot checkout the commit ID %s: '%s'", commitId, err)
-	}
-	return nil
-}
 
 func getRemoteCommitHash(r repository, remote, branch string) *plumbing.Hash {
 	remoteBranch := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)

--- a/internal/repository/git.go
+++ b/internal/repository/git.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/go-git/go-git/v5/plumbing/transport/ssh"
 	"github.com/nlewo/comin/internal/types"
 	"github.com/sirupsen/logrus"
 )
@@ -81,6 +82,26 @@ func fetch(r repository, remote types.Remote) (err error) {
 			Username: remote.Auth.Username,
 			Password: remote.Auth.AccessToken,
 		}
+	} else if remote.Auth.SshDeployKeyPath != "" {
+		sshPubKeyAuth, err := ssh.NewPublicKeysFromFile(remote.Auth.Username, remote.Auth.SshDeployKeyPath, "")
+		if err != nil {
+			logrus.Errorf("Failed to load SSH private key from '%s': %s", remote.Auth.SshDeployKeyPath, err)
+			return fmt.Errorf("loading SSH private key failed: %s", err)
+		}
+		// Set the host key callback explicitly. Otherwise go-git builds a
+		// default one from $HOME/.ssh/known_hosts, which fails with
+		// "$HOME is not defined" when running as a systemd service.
+		knownHostsPath := remote.Auth.SshKnownHostsPath
+		if knownHostsPath == "" {
+			knownHostsPath = "/etc/ssh/ssh_known_hosts"
+		}
+		hostKeyCallback, err := ssh.NewKnownHostsCallback(knownHostsPath)
+		if err != nil {
+			logrus.Errorf("Failed to load SSH known_hosts from '%s'", knownHostsPath)
+			return fmt.Errorf("loading SSH known_hosts file failed: %s", knownHostsPath)
+		}
+		sshPubKeyAuth.HostKeyCallback = hostKeyCallback
+		fetchOptions.Auth = sshPubKeyAuth
 	}
 
 	// TODO: we should get a parent context

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -715,6 +715,29 @@ func TestTestingHardReset(t *testing.T) {
 	assert.Equal(t, "r1", r.RepositoryStatus.SelectedRemoteName)
 }
 
+func TestFetchSshBadKeyPath(t *testing.T) {
+	r1Dir := t.TempDir()
+	cominRepositoryDir := t.TempDir()
+	_, _ = initRemoteRepostiory(r1Dir, true)
+	gitConfig := types.GitConfig{
+		Path: cominRepositoryDir,
+		Remotes: []types.Remote{{
+			Name: "r1",
+			URL:  r1Dir,
+			Auth: types.Auth{
+				SshDeployKeyPath: "/nonexistent/key",
+				Username:         "git",
+			},
+			Branches: types.Branches{Main: types.Branch{Name: "main"}},
+			Timeout:  30,
+		}},
+	}
+	r, err := New(gitConfig, "", prometheus.New())
+	assert.Nil(t, err)
+	r.Fetch([]string{"r1"})
+	assert.NotEmpty(t, r.RepositoryStatus.Remotes[0].FetchErrorMsg)
+}
+
 func TestUpdateGpg(t *testing.T) {
 	dir := t.TempDir()
 	cominRepositoryDir := t.TempDir()

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -30,9 +30,11 @@ type GitConfig struct {
 }
 
 type Auth struct {
-	AccessToken     string
-	AccessTokenPath string `yaml:"access_token_path"`
-	Username        string
+	AccessToken       string
+	AccessTokenPath   string `yaml:"access_token_path"`
+	SshDeployKeyPath  string `yaml:"ssh_deploy_key_path"`
+	SshKnownHostsPath string `yaml:"ssh_known_hosts_path"`
+	Username          string
 }
 
 type Branch struct {

--- a/nix/module-options.nix
+++ b/nix/module-options.nix
@@ -158,6 +158,23 @@ in
                         username is valid on GitLab and GitHub.
                       '';
                     };
+                    ssh_deploy_key_path = mkOption {
+                      type = nullOr path;
+                      default = null;
+                      description = ''
+                        Path to the SSH private key used to authenticate to the Git remote.
+                      '';
+                    };
+                    ssh_known_hosts_path = mkOption {
+                      type = nullOr path;
+                      default = null;
+                      description = ''
+                        Path to the known_hosts file used to verify the SSH
+                        host key of the Git remote. Defaults to
+                        /etc/ssh/ssh_known_hosts when unset. The remote's host
+                        key must be present in this file.
+                      '';
+                    };
                   };
                 };
               };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -37,7 +37,11 @@ in
         assertion = package == null -> lib.elem system (lib.attrNames self.packages);
         message = "comin: ${system} is not supported by the Flake.";
       }
-    ];
+    ]
+    ++ lib.forEach cfg.services.comin.remotes (remote: {
+      assertion = !(remote.auth.access_token_path != "" && remote.auth.ssh_deploy_key_path != "");
+      message = "comin: remote `${remote.name}` sets both `auth.access_token_path` and `auth.ssh_deploy_key_path`; set at most one.";
+    });
 
     systemd.user.services.comin-desktop = lib.mkIf cfg.services.comin.desktop.enable {
       wantedBy = [ "graphical-session.target" ];


### PR DESCRIPTION
## Summary

Implement SSH public key authentication for git remotes.

https://github.com/nlewo/comin/issues/37

## Changes

- Add new `remote.auth.ssh_deploy_key_path` option specifying path to SSH private key to use for remote authentication
- Add new `remote.auth.ssh_known_hosts_path` option specifying SSH known host keys file (defaults to /etc/ssh/ssh_known_hosts)

## Testing

These changes were tested by repointing my comin flake input to this branch/fork and confirming a successfully deployment via comin log output.

