### PR TITLE
metrics: fix reboot-required race condition

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -87,6 +87,7 @@ var runCmd = &cobra.Command{
 		if err := store.Load(); err != nil {
 			logrus.Errorf("Ignoring the state file %s because of the loading error: %s", storeFilename, err)
 		}
+		prometheus.Subscribe(broker, &metrics)
 		metrics.SetBuildInfo(cmd.Version)
 
 		// We get the last mainCommitId to avoid useless
@@ -141,8 +142,6 @@ var runCmd = &cobra.Command{
 			cfg.Exporter.ListenAddress, cfg.Exporter.Port)
 		srv := server.New(broker, manager, cfg.Grpc.UnixSocketPath)
 		srv.Start()
-
-		prometheus.Subscribe(broker, &metrics)
 
 		manager.Run(cmd.Context())
 	},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -86,6 +86,7 @@ var runCmd = &cobra.Command{
 		if err := store.Load(); err != nil {
 			logrus.Errorf("Ignoring the state file %s because of the loading error: %s", storeFilename, err)
 		}
+		prometheus.Subscribe(broker, &metrics)
 		metrics.SetBuildInfo(cmd.Version)
 
 		// We get the last mainCommitId to avoid useless
@@ -141,8 +142,6 @@ var runCmd = &cobra.Command{
 			cfg.Exporter.ListenAddress, cfg.Exporter.Port)
 		srv := server.New(broker, manager, cfg.Grpc.UnixSocketPath)
 		srv.Start()
-
-		prometheus.Subscribe(broker, &metrics)
 
 		manager.Run(cmd.Context())
 	},

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -241,6 +241,10 @@ func (m *Manager) Run(ctx context.Context) {
 	lastDpl := m.deployer.State().Deployment
 	if lastDpl != nil {
 		m.needToReboot = m.executor.NeedToReboot(lastDpl.Generation.OutPath, lastDpl.Operation)
+		if m.needToReboot {
+			e := &protobuf.Event_RebootRequired{Deployment: lastDpl}
+			m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_RebootRequired_{RebootRequired: e}, CreatedAt: timestamppb.New(time.Now().UTC())})
+		}
 	}
 
 	m.FetchAndBuild(ctx)

--- a/internal/manager/manager.go
+++ b/internal/manager/manager.go
@@ -254,6 +254,10 @@ func (m *Manager) Run(ctx context.Context) {
 	lastDpl := m.deployer.State().Deployment
 	if lastDpl != nil {
 		m.needToReboot = m.executor.NeedToReboot(lastDpl.Generation.OutPath, lastDpl.Operation)
+		if m.needToReboot {
+			e := &protobuf.Event_RebootRequired{Deployment: lastDpl}
+			m.broker.Publish(&protobuf.Event{Type: &protobuf.Event_RebootRequired_{RebootRequired: e}, CreatedAt: timestamppb.New(time.Now().UTC())})
+		}
 	}
 
 	m.FetchAndBuild(ctx)


### PR DESCRIPTION
I found a race condition in the reboot required metric.

It was caused by:
- the manager not sending "reboot required" over the broker upon startup
  - (I think. I am not sure `comin watch` does report the reboot required correctly, but I verified /both/ changes were necessary so I believe this is the case)
- the metrics subscribing to the broker too late, missing the "reboot required" event