### PR TITLE
types: read confirmer duration from autoconfirm_duration

### DIFF
--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -61,7 +61,7 @@ type Grpc struct {
 
 type Confirmer struct {
 	Mode         string `yaml:"mode"`
-	AutoDuration int    `yaml:"auto_duration"`
+	AutoDuration int    `yaml:"autoconfirm_duration"`
 }
 
 type Retention struct {


### PR DESCRIPTION
## Problem

`deployConfirmer.autoconfirm_duration` (and `buildConfirmer`) is ignored. With `mode = "auto"`, generations are confirmed immediately instead of after the configured duration.

The NixOS module writes the yaml key `autoconfirm_duration` (`nix/module-options.nix` + `nix/comin-config.nix`), but the `Confirmer` struct tag was `auto_duration`, so `AutoDuration` stayed at `0`:

```
confirmer: starting with the autoconfirm duration: 0 seconds
```

## Fix

One line — align the struct tag with the module option and the docs:

```diff
-	AutoDuration int    `yaml:"auto_duration"`
+	AutoDuration int    `yaml:"autoconfirm_duration"`
```

Non-breaking: the module already emits `autoconfirm_duration`, and the option/docs already use that name. Affects both the build and the deploy confirmer.

Fixes #179