### PR TITLE
fix: desktop service crash-loop on startup notification failure

### DIFF
--- a/cmd/desktop.go
+++ b/cmd/desktop.go
@@ -29,7 +29,7 @@ var desktopCmd = &cobra.Command{
 		}
 		err := beeep.Notify(title, "Agent desktop notifications started.", []byte{})
 		if err != nil {
-			panic(err)
+			logrus.Warnf("failed to send the startup notification: %s", err)
 		}
 
 		test, _ := cmd.Flags().GetBool("test")


### PR DESCRIPTION
## Problem

On startup the banner notification may fire before the daemon is ready on
the session bus (common `graphical-session.target` race). `beeep` fails
and `cmd/desktop.go:32` `panic(err)`s, exiting code 2 and crash-looping:

    panic: beeep: dbus: unexpected EOF; notify-send: exit status 1; ...

## Fix

`panic` → `logrus.Warnf`. The banner is decorative; missing it doesn't
affect event subscription.

Mirrors `handler()` in the same file (`desktop.go:139` uses
`logrus.Errorf` for functional event notifications) but at lower severity
— event misses cost the user build/deploy events, banner misses don't.

Complementary to #148 (adds a `Restart=` fallback; this removes the root cause).

## Testing

`go build && go vet && go test` all pass; manually verified — starting
before the daemon is ready now warns instead of panicking.
