### PR TITLE
fix(desktop): handle post-refactor event types, publish ConfirmationSubmitted

### DIFF
--- a/cmd/desktop.go
+++ b/cmd/desktop.go
@@ -141,6 +141,23 @@ func handler(event *protobuf.Event) error {
 		}
 	case *protobuf.Event_RebootRequired_:
 		message = "The machine needs to be rebooted to take the deployment into account."
+	// High-frequency/internal events: silenced (empty case avoids default-branch error spam)
+	case *protobuf.Event_ManagerState_: // startup state sync
+	case *protobuf.Event_Fetched_: // poll tick (default 60s; notifying would spam)
+	case *protobuf.Event_Log_: // streaming build/deploy logs
+	// Confirmation lifecycle events
+	case *protobuf.Event_ConfirmationSubmittedType:
+		c := event.Type.(*protobuf.Event_ConfirmationSubmittedType).ConfirmationSubmittedType
+		switch c.Mode {
+		case "without": // immediately confirmed, no user action needed (e.g. default build confirmer)
+		case "auto":
+			message = "A deployment is pending confirmation (auto-confirming shortly)."
+		default: // manual
+			message = "A deployment is pending confirmation."
+		}
+	case *protobuf.Event_ConfirmationConfirmedType: // immediately followed by DeploymentStarted, redundant
+	case *protobuf.Event_ConfirmationCancelledType:
+		message = "The deployment has been cancelled."
 	}
 	if message != "" {
 		err := beeep.Notify(title, message, []byte{})

--- a/internal/manager/confirmer.go
+++ b/internal/manager/confirmer.go
@@ -114,12 +114,15 @@ func (c *Confirmer) start() {
 			case "submit":
 				notified = false
 				c.state.Submitted = command.uuid
+				var modeStr string
 				switch Mode(c.state.Mode) {
 				case Manual:
 					logrus.Infof("confirmer: generation %s has been submitted", command.uuid)
+					modeStr = "manual"
 				case Without:
 					logrus.Infof("confirmer: generation %s has been submitted and confirmed", command.uuid)
 					c.state.Confirmed = command.uuid
+					modeStr = "without"
 				case Auto:
 					logrus.Infof("confirmer: generation %s has been submitted and will be confirmed in %d seconds", command.uuid, c.state.AutoconfirmDuration)
 					if c.timer != nil {
@@ -129,7 +132,11 @@ func (c *Confirmer) start() {
 					timer = c.timer.C
 					c.state.AutoconfirmStarted = wrapperspb.Bool(true)
 					c.state.AutoconfirmStartedAt = timestamppb.New(time.Now().UTC())
+					modeStr = "auto"
 				}
+				// Notify subscribers that a generation entered the confirmation flow (buffer window started / immediate / not needed)
+				submittedEvent := &protobuf.Event_ConfirmationSubmitted{Mode: modeStr, Uuid: command.uuid}
+				c.broker.Publish(&protobuf.Event{Type: &protobuf.Event_ConfirmationSubmittedType{ConfirmationSubmittedType: submittedEvent}, CreatedAt: timestamppb.New(time.Now().UTC())})
 			case "confirm":
 				logrus.Infof("confirmer: generation %s has been confirmed", command.uuid)
 				c.state.Confirmed = command.uuid


### PR DESCRIPTION
Fixes #182

## Problem

The desktop handler's type switch in `cmd/desktop.go` was never updated
after #126 and #172, so the new event types (`ManagerState`, `Fetched`,
`Log`, `Confirmation*`) all hit `default` — logged as `unexpected type %T`
and dropped (#182 error spam; confirmation lifecycle invisible to desktop
users).

Also, `ConfirmationSubmitted` is defined in `services.proto` but never
published — unlike its `Confirmed`/`Cancelled` siblings.

## Fix

**`internal/manager/confirmer.go`** — publish `ConfirmationSubmitted` from
the `submit` branch.

**`cmd/desktop.go`** — add the missing cases:
- Silenced (spam/redundant): `ManagerState`, `Fetched`, `Log`,
  `ConfirmationConfirmed`.
- Notify: `ConfirmationSubmitted` (by mode: `manual`/`auto`/`without`),
  `ConfirmationCancelled`.

Both sides are mutually dependent, hence one PR.

## Testing

`go build` / `go vet` / `go test ./...` pass. Manually verified no more
`unexpected type` errors; confirmation events now notify.
