### PR TITLE
fix: don't record a build cancelled by a newer commit as failed

### DIFF
--- a/internal/builder/builder_test.go
+++ b/internal/builder/builder_test.go
@@ -272,3 +272,66 @@ func TestBuilderSuspend(t *testing.T) {
 		assert.True(c, b.isBuilding.Load())
 	}, 3*time.Second, 100*time.Millisecond)
 }
+
+// The scenario that produces the false alarm: a build is running when a newer
+// commit arrives, Eval preempts it, and the preempted generation must not be
+// left looking like a build failure. comin_last_build_failed is derived from
+// this status, so recording it as failed makes two closely-spaced commits
+// indistinguishable from a broken build until the retry finishes.
+func TestBuilderPreemptedBuildIsCanceledNotFailed(t *testing.T) {
+	tmp := t.TempDir()
+	bk := broker.New()
+	bk.Start()
+
+	s, err := store.New(bk, tmp+"/state.json", tmp+"/gcroots", 1, 1, 2)
+	assert.Nil(t, err)
+	eMock := NewExecutorMock(false)
+	b := New(s, eMock, bk, "", "", "", "", false, 5*time.Second, 5*time.Second)
+	ctx := t.Context()
+
+	generation1 := s.NewGeneration("", "", "", &protobuf.GitRepositoryStatus{SelectedCommitId: "commit-1"})
+	_ = b.Eval(ctx, &generation1)
+	eMock.evalDone <- struct{}{}
+	gUUID := <-b.EvaluationDone
+
+	assert.Nil(t, b.build(ctx, gUUID))
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, b.isBuilding.Load())
+	}, 2*time.Second, 100*time.Millisecond)
+
+	// A newer commit lands while commit-1 is still building.
+	generation2 := s.NewGeneration("", "", "", &protobuf.GitRepositoryStatus{SelectedCommitId: "commit-2"})
+	_ = b.Eval(ctx, &generation2)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		g, err := b.store.GenerationGet(gUUID)
+		assert.Nil(c, err)
+		assert.Equal(c, store.BuildCanceled.String(), g.BuildStatus)
+		assert.NotEqual(c, store.BuildFailed.String(), g.BuildStatus)
+	}, 2*time.Second, 100*time.Millisecond)
+}
+
+// A build that hits its timeout is a real failure and must keep reporting one.
+func TestBuilderTimedOutBuildIsStillFailed(t *testing.T) {
+	tmp := t.TempDir()
+	bk := broker.New()
+	bk.Start()
+
+	s, err := store.New(bk, tmp+"/state.json", tmp+"/gcroots", 1, 1, 1)
+	assert.Nil(t, err)
+	eMock := NewExecutorMock(false)
+	b := New(s, eMock, bk, "", "", "", "", false, 5*time.Second, 1*time.Second)
+	ctx := t.Context()
+
+	generation := s.NewGeneration("", "", "", &protobuf.GitRepositoryStatus{})
+	_ = b.Eval(ctx, &generation)
+	eMock.evalDone <- struct{}{}
+	gUUID := <-b.EvaluationDone
+
+	assert.Nil(t, b.build(ctx, gUUID))
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		g, err := b.store.GenerationGet(gUUID)
+		assert.Nil(c, err)
+		assert.Equal(c, store.BuildFailed.String(), g.BuildStatus)
+	}, 3*time.Second, 100*time.Millisecond, "a build timeout must still be a failure")
+}

--- a/internal/store/generation.go
+++ b/internal/store/generation.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
 	"slices"
@@ -22,6 +24,9 @@ const (
 	Evaluating
 	Evaluated
 	EvalFailed
+	// EvalCanceled is an evaluation that was preempted by a newer
+	// commit rather than one that errored. See BuildCanceled.
+	EvalCanceled
 )
 
 func (s EvalStatus) String() string {
@@ -34,6 +39,8 @@ func (s EvalStatus) String() string {
 		return "evaluated"
 	case EvalFailed:
 		return "failed"
+	case EvalCanceled:
+		return "canceled"
 	}
 	return "unknown"
 }
@@ -48,6 +55,8 @@ func StringToEvalStatus(statusStr string) EvalStatus {
 		return Evaluated
 	case "failed":
 		return EvalFailed
+	case "canceled":
+		return EvalCanceled
 	default:
 		return EvalInit // Default value
 	}
@@ -60,6 +69,14 @@ const (
 	Building
 	Built
 	BuildFailed
+	// BuildCanceled is a build that was preempted by a newer commit.
+	// Builder.Eval calls Builder.Stop() before starting a new
+	// generation, which cancels the build context, so this is a
+	// routine part of operation and not an error: the newer
+	// generation is built immediately afterwards. Keeping it out of
+	// BuildFailed is what stops comin_last_build_failed from
+	// alarming every time two commits land close together.
+	BuildCanceled
 )
 
 func (s BuildStatus) String() string {
@@ -72,6 +89,8 @@ func (s BuildStatus) String() string {
 		return "built"
 	case BuildFailed:
 		return "failed"
+	case BuildCanceled:
+		return "canceled"
 	}
 	return "unknown"
 }
@@ -86,6 +105,8 @@ func StringToBuildStatus(statusStr string) BuildStatus {
 		return Built
 	case "failed":
 		return BuildFailed
+	case "canceled":
+		return BuildCanceled
 	default:
 		return BuildInit
 	}
@@ -151,6 +172,8 @@ func GenerationShow(g *protobuf.Generation) {
 		fmt.Printf("%s  DrvPath: %s\n", padding, g.DrvPath)
 	case EvalFailed.String():
 		fmt.Printf("%sEvaluation failed %s\n", padding, humanize.Time(g.EvalEndedAt.AsTime()))
+	case EvalCanceled.String():
+		fmt.Printf("%sEvaluation canceled %s\n", padding, humanize.Time(g.EvalEndedAt.AsTime()))
 	}
 	if g.BuildStatus == BuildInit.String() {
 		fmt.Printf("%sNo build started\n", padding)
@@ -166,6 +189,8 @@ func GenerationShow(g *protobuf.Generation) {
 		fmt.Printf("%s  Outpath:  %s\n", padding, g.OutPath)
 	case BuildFailed.String():
 		fmt.Printf("%sBuild failed %s\n", padding, humanize.Time(g.BuildEndedAt.AsTime()))
+	case BuildCanceled.String():
+		fmt.Printf("%sBuild canceled %s\n", padding, humanize.Time(g.BuildEndedAt.AsTime()))
 	}
 }
 
@@ -210,7 +235,10 @@ func (s *Store) GenerationEvalFinished(uuid string, drvPath, outPath, machineId 
 	if err != nil {
 		return err
 	}
-	if evalErr != nil {
+	if errors.Is(evalErr, context.Canceled) {
+		g.EvalErr = evalErr.Error()
+		g.EvalStatus = EvalCanceled.String()
+	} else if evalErr != nil {
 		g.EvalErr = evalErr.Error()
 		g.EvalStatus = EvalFailed.String()
 	} else {
@@ -267,6 +295,9 @@ func (s *Store) GenerationBuildFinished(uuid string, buildErr error) error {
 		if err := os.Symlink(g.OutPath, s.generationGcRoot); err != nil {
 			logrus.Errorf("Could not create the gcroot symlink for the generation %s: %s", g.Uuid, err)
 		}
+	} else if errors.Is(buildErr, context.Canceled) {
+		g.BuildStatus = BuildCanceled.String()
+		g.BuildErr = buildErr.Error()
 	} else {
 		g.BuildStatus = BuildFailed.String()
 		g.BuildErr = buildErr.Error()

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,6 +1,8 @@
 package store
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"testing"
@@ -247,4 +249,58 @@ func TestCompareSwitchInhibitors(t *testing.T) {
 	// Test with both maps empty
 	diff = compareSwitchInhibitors(map[string]string{}, map[string]string{})
 	assert.Len(t, diff, 0)
+}
+
+// A build preempted by a newer commit finishes with context.Canceled. It must
+// not be recorded as a failure: comin_last_build_failed is derived from this
+// status, so folding cancellation into BuildFailed makes every pair of
+// closely-spaced commits look like a broken build until the retry completes.
+func TestGenerationBuildCanceledIsNotAFailure(t *testing.T) {
+	tmp := t.TempDir()
+	bk := broker.New()
+	bk.Start()
+	s, err := New(bk, tmp+"/filename", tmp+"/gcroots", 2, 2, 5)
+	assert.Nil(t, err)
+
+	g := s.NewGeneration("hostname", "repositoryDir", "systemAttr", &protobuf.GitRepositoryStatus{})
+	assert.Nil(t, s.GenerationEvalStarted(g.Uuid))
+	assert.Nil(t, s.GenerationEvalFinished(g.Uuid, "drvPath", "outPath", "machineId", context.Canceled))
+
+	got, err := s.GenerationGet(g.Uuid)
+	assert.Nil(t, err)
+	assert.Equal(t, EvalCanceled.String(), got.EvalStatus)
+	assert.NotEqual(t, EvalFailed.String(), got.EvalStatus)
+
+	g2 := s.NewGeneration("hostname", "repositoryDir", "systemAttr", &protobuf.GitRepositoryStatus{})
+	assert.Nil(t, s.GenerationEvalStarted(g2.Uuid))
+	assert.Nil(t, s.GenerationEvalFinished(g2.Uuid, "drvPath", "outPath", "machineId", nil))
+	assert.Nil(t, s.GenerationBuildStart(g2.Uuid, "reason"))
+	assert.Nil(t, s.GenerationBuildFinished(g2.Uuid, context.Canceled))
+
+	got2, err := s.GenerationGet(g2.Uuid)
+	assert.Nil(t, err)
+	assert.Equal(t, BuildCanceled.String(), got2.BuildStatus)
+	assert.NotEqual(t, BuildFailed.String(), got2.BuildStatus)
+	// The output path was never realised, so the generation still has to be
+	// built and must not be mistaken for a successful one.
+	assert.True(t, GenerationHasToBeBuilt(&got2))
+}
+
+// A genuine build error must still be recorded as a failure.
+func TestGenerationBuildErrorIsAFailure(t *testing.T) {
+	tmp := t.TempDir()
+	bk := broker.New()
+	bk.Start()
+	s, err := New(bk, tmp+"/filename", tmp+"/gcroots", 2, 2, 5)
+	assert.Nil(t, err)
+
+	g := s.NewGeneration("hostname", "repositoryDir", "systemAttr", &protobuf.GitRepositoryStatus{})
+	assert.Nil(t, s.GenerationEvalStarted(g.Uuid))
+	assert.Nil(t, s.GenerationEvalFinished(g.Uuid, "drvPath", "outPath", "machineId", nil))
+	assert.Nil(t, s.GenerationBuildStart(g.Uuid, "reason"))
+	assert.Nil(t, s.GenerationBuildFinished(g.Uuid, errors.New("boom")))
+
+	got, err := s.GenerationGet(g.Uuid)
+	assert.Nil(t, err)
+	assert.Equal(t, BuildFailed.String(), got.BuildStatus)
 }

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -158,6 +158,10 @@ func (bm BuilderModel) View() string {
 			b.WriteString("  " + labelStyle.Render("Eval:    ") +
 				errorStyle.Render("failed") +
 				fmt.Sprintf(" %s\n", formatTime(g.EvalEndedAt.AsTime())))
+		case store.EvalCanceled.String():
+			b.WriteString("  " + labelStyle.Render("Eval:    ") +
+				"canceled" +
+				fmt.Sprintf(" %s\n", formatTime(g.EvalEndedAt.AsTime())))
 		}
 
 		switch g.BuildStatus {
@@ -172,6 +176,10 @@ func (bm BuilderModel) View() string {
 		case store.BuildFailed.String():
 			b.WriteString("  " + labelStyle.Render("Build:   ") +
 				errorStyle.Render("failed") +
+				fmt.Sprintf(" %s\n", formatTime(g.BuildEndedAt.AsTime())))
+		case store.BuildCanceled.String():
+			b.WriteString("  " + labelStyle.Render("Build:   ") +
+				"canceled" +
 				fmt.Sprintf(" %s\n", formatTime(g.BuildEndedAt.AsTime())))
 		}
 	}


### PR DESCRIPTION
Fixes #187.

## Problem

`Builder.Eval` preempts whatever is running before starting a new generation:

```go
// This is to prempt the builder since we don't need to allow
// several evaluation in parallel
b.Stop()
```

The cancelled build surfaces as `context.Canceled` (asserted in
`internal/builder/exec_test.go`), and `GenerationBuildFinished` had a single
non-nil branch, so cancellation was recorded as `BuildFailed`. The metrics
subscriber reads that status verbatim, so `comin_last_build_failed` went to 1
and stayed latched until the *retry* build finished.

The practical effect is that two commits landing a few minutes apart look
exactly like a broken build, for as long as a full rebuild takes on that host.
On my fleet that meant three of four hosts raising a critical alert while every
host was building normally, with zero `level=error` lines in the journal (see
#187 for the full trace).

## Change

Cancellation gets its own terminal state, `BuildCanceled` / `EvalCanceled`
(string `"canceled"`), set when `errors.Is(err, context.Canceled)`.

Marking it `Built` would be wrong: the output path was never realised, and the
gcroot symlink must not point at it. `GenerationHasToBeBuilt` therefore still
reports true for a cancelled generation, so the retry proceeds exactly as
before.

A build that hits its timeout is `context.DeadlineExceeded`, which does not
match `errors.Is(err, context.Canceled)` — timeouts remain failures.

`internal/prometheus/prometheus.go` needs no change: it compares the status
against `"failed"`, which now simply excludes cancellations.

The TUI gets display arms for the new state so the Build/Eval line does not
silently disappear when a generation is preempted.

## Tests

- `TestBuilderPreemptedBuildIsCanceledNotFailed` reproduces the actual
  scenario at the builder level (a build is running, a newer commit arrives,
  `Eval` preempts it) using the existing `ExecutorMock` harness.
- `TestBuilderTimedOutBuildIsStillFailed` pins the timeout case so it cannot
  regress into "canceled".
- `TestGenerationBuildCanceledIsNotAFailure` covers the store transition for
  both eval and build, including that the generation still has to be built.
- `TestGenerationBuildErrorIsAFailure` pins ordinary build errors.

Reverting the two `errors.Is` branches makes the first and third tests fail
with `expected: "canceled" / actual: "failed"`, so they do capture the bug
rather than merely describing the new code. `go test -race ./...` passes.

## Notes

- The new status string is persisted in `store.json`. Downgrading to an older
  comin makes `StringToBuildStatus` fall back to `BuildInit` for those
  generations; I assumed that is acceptable, but say the word if you would
  rather encode this without a new state.
- `BuildErr` is still populated for cancellations (`"context canceled"`), on
  the grounds that keeping the reason is more useful than dropping it.
- Two files in the repo are not `gofmt`-clean on main; I left those unrelated
  lines untouched to keep the diff focused.
- Verified through the test suite only — I have not yet run a patched comin on
  real hosts to watch the metric stay at 0 across a live double merge.
- Written with AI assistance; I reviewed and tested the result myself.
